### PR TITLE
Potential fix for code scanning alert no. 22: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/xcore/kernel/api/router.py
+++ b/xcore/kernel/api/router.py
@@ -37,12 +37,13 @@ _api_key_header = APIKeyHeader(
 )
 
 
-def _hash_key(key: Optional[str | bytes]) -> bytes:
-    """Hash SHA256 de la clé API."""
+def _normalize_key(key: Optional[str | bytes]) -> bytes:
+    """Normalise la clé API en bytes pour comparaison sécurisée."""
     if isinstance(key, bytes):
-        return hashlib.sha256(key.decode("utf-8").encode("utf-8")).digest()
+        # On force un encodage UTF-8 cohérent si possible
+        return key.decode("utf-8").encode("utf-8")
     else:
-        return hashlib.sha256(key.encode("utf-8")).digest()
+        return key.encode("utf-8")
 
 
 def build_router(
@@ -58,8 +59,8 @@ def build_router(
 
     tags = tags or []
 
-    # On hash une seule fois au démarrage
-    stored_hash = _hash_key(secret_key)
+    # On normalise une seule fois au démarrage
+    stored_key = _normalize_key(secret_key)
 
     async def verify_api_key(
         api_key: str | None = Security(_api_key_header),
@@ -71,10 +72,10 @@ def build_router(
                 detail="API key missing",
             )
 
-        incoming_hash = _hash_key(api_key)
+        incoming_key = _normalize_key(api_key)
 
         # Comparaison sécurisée anti timing attack
-        if not hmac.compare_digest(incoming_hash, stored_hash):
+        if not hmac.compare_digest(incoming_key, stored_key):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Unauthorized",


### PR DESCRIPTION
Potential fix for [https://github.com/traoreera/xcore/security/code-scanning/22](https://github.com/traoreera/xcore/security/code-scanning/22)

General approach: Avoid using a fast cryptographic hash function (SHA‑256) on sensitive “password‑like” data in a way that static analysis interprets as password hashing. In this context we do not need a password‑hashing KDF (bcrypt/Argon2), because we are not storing/verifying offline; instead, we can compare the API key in constant time directly. So the best fix is to remove the SHA‑256 hashing and normalize/compare the secrets as bytes with `hmac.compare_digest`.

Concrete fix:

- Remove the `_hash_key` helper that hashes the key with SHA‑256.
- Replace the stored value `stored_hash` with a stored, normalized byte representation of the `secret_key`, e.g. `stored_key = _normalize_key(secret_key)` where `_normalize_key` converts `str`/`bytes` to `bytes`.
- When verifying the incoming `api_key`, normalize it in the same way and call `hmac.compare_digest(incoming_key, stored_key)` directly.
- This keeps constant‑time comparison and avoids SHA‑256 entirely, satisfying CodeQL and keeping security properties.

Changes (all in `xcore/kernel/api/router.py`):

1. Replace `_hash_key` with a `_normalize_key` function that only does encoding/decoding, no hashing.
2. In `build_router`, change `stored_hash = _hash_key(secret_key)` to `stored_key = _normalize_key(secret_key)`.
3. In `verify_api_key`, change `incoming_hash = _hash_key(api_key)` and the `compare_digest` call to use the normalized keys (`incoming_key` vs. `stored_key`).

No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Avoid use of a fast cryptographic hash (SHA-256) for password-like API key comparison by switching to direct byte comparison with hmac.compare_digest.