### PR TITLE
add `from_raw` method on plugin dependencecy

### DIFF
--- a/xcore/kernel/events/bus.py
+++ b/xcore/kernel/events/bus.py
@@ -100,7 +100,7 @@ class EventBus:
         """
         Issues an event.
         `gather=True` → handlers executed in parallel (`asyncio.gather`)
-        `gather=False` → sequential, `stop_propagation` respected
+        `gather=False` → sequential, `propagate` respected
         eg:
         ```python
             await bus.emit("user.created", {"email": "alice@example.com"})

--- a/xcore/kernel/events/hooks.py
+++ b/xcore/kernel/events/hooks.py
@@ -187,7 +187,7 @@ class HookManager:
         to_remove: List[Tuple[str, Callable]] = []
 
         for pattern, hook_info in matching:
-            if event.stop_propagation:
+            if event.propagate:
                 break
             result = await self._execute_single_hook(hook_info, event, pattern)
             results.append(result)

--- a/xcore/kernel/events/section.py
+++ b/xcore/kernel/events/section.py
@@ -1,7 +1,7 @@
 
 from __future__ import annotations
 from enum import Enum
-from typing import Any, Callable, NamedTuple, Optional
+from typing import Any, Callable, NamedTuple, Optional, Dict
 
 
 from dataclasses import dataclass, field
@@ -9,19 +9,18 @@ from typing import Any
 
 @dataclass
 class Event:
-    """Évent struct for handlers."""
-
     name: str
-    data: dict[str, Any] = field(default_factory=dict)
+    payload: dict
     source: str | None = None
     propagate: bool = True
-    cancelled: bool = False
 
-    def stop(self) -> None:
+    # compat legacy
+    metadata: dict | None = None
+    stop_propagation: bool = False
+
+    def stop(self):
         self.propagate = False
-
-    def cancel(self) -> None:
-        self.cancelled = True
+        self.stop_propagation = True
 
 
 @dataclass

--- a/xcore/sdk/plugin_base.py
+++ b/xcore/sdk/plugin_base.py
@@ -95,9 +95,30 @@ class PluginDependency:
     def __eq__(self, other: object) -> bool:
         if isinstance(other, PluginDependency):
             return self.name == other.name
-        if isinstance(other, str):
-            return self.name == other
-        return False
+        return self.name == other if isinstance(other, str) else False
+    @classmethod
+    def from_raw(cls, raw: str | dict) -> "PluginDependency":
+        """
+        Convertit un élément YAML de `requires` en PluginDependency.
+
+        Formats supportés:
+            - "plugin_name"
+            - {name: plugin_name}
+            - {name: plugin_name, version: ">=1.0,<2.0"}
+        """
+
+        if isinstance(raw, str):
+            return cls(name=raw, version_constraint="*")
+
+        if isinstance(raw, dict):
+            name = raw.get("name")
+            if not name:
+                raise ValueError("Plugin dependency requires a 'name' field")
+
+            version = raw.get("version", "*")
+            return cls(name=name, version_constraint=version)
+
+        raise TypeError(f"Invalid dependency format: {raw}")
 
 
 class VersionConstraint:
@@ -127,7 +148,11 @@ class VersionConstraint:
     def _to_tuple(self, version: str) -> tuple[int, ...]:
         """Convertit '1.2.3' en (1, 2, 3)."""
         parts = version.lstrip("vV").split(".")
-        return tuple(int(p) for p in parts if p.isdigit())
+        nums = [int(p) for p in parts if p.isdigit()]
+        while len(nums) < 3:
+            nums.append(0)
+        return tuple(nums)
+    
 
     def matches(self, version: str) -> bool:
         """Vérifie si 'version' satisfait cette contrainte."""
@@ -146,13 +171,13 @@ class VersionConstraint:
                 return False
             if op == "<" and not (target < spec):
                 return False
-            if op == "^":  # Compatible avec version (semver caret)
+            if op == "^":
                 # ^1.2.3 := >=1.2.3,<2.0.0
                 if not (target >= spec):
                     return False
                 if target[0] != spec[0]:
                     return False
-            if op == "~":  # Approximativement équivalent (semver tilde)
+            elif op == "~":
                 # ~1.2.3 := >=1.2.3,<1.3.0
                 if not (target >= spec):
                     return False


### PR DESCRIPTION
update `Event` dataclass to accept retro-compatibilite with `hooks` and `bus` systeme
fix bug

## Summary by Sourcery

Introduce a helper for constructing plugin dependencies from raw configuration and align the event model and version constraint handling with existing hooks and bus semantics.

New Features:
- Add a PluginDependency.from_raw constructor to build dependencies from string or dict representations in configuration.

Bug Fixes:
- Normalize version parsing to always produce three-part tuples, fixing edge cases in version constraint comparison.
- Correct the conditional logic in hooks emission to respect the event propagation flag as intended.

Enhancements:
- Simplify PluginDependency equality comparison with strings.
- Adjust caret and tilde version constraint handling to use mutually exclusive branches.
- Refine the Event dataclass fields and stop method for compatibility with legacy hook and bus systems, including renaming and adding compatibility attributes.
- Clarify event bus documentation to refer to the propagate flag instead of stop_propagation.

Documentation:
- Update event bus emit docstring to describe propagation behavior using the current propagate flag.