### PR TITLE
Potential fix for code scanning alert no. 21: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/xcore/kernel/api/router.py
+++ b/xcore/kernel/api/router.py
@@ -14,6 +14,11 @@ from fastapi.security import APIKeyHeader
 from pydantic import BaseModel, Field
 
 
+# PBKDF2 configuration for API key hashing
+_API_KEY_PBKDF2_SALT = b"xcore-router-api-key-salt"
+_API_KEY_PBKDF2_ITERATIONS = 100_000
+
+
 class CallRequest(BaseModel):
     """call request body."""
 
@@ -38,11 +43,19 @@ _api_key_header = APIKeyHeader(
 
 
 def _hash_key(key: Optional[str | bytes]) -> bytes:
-    """Hash SHA256 de la clé API."""
-    if isinstance(key, bytes):
-        return hashlib.sha256(key.decode("utf-8").encode("utf-8")).digest()
+    """Derive a hash of the API key using a computationally expensive KDF (PBKDF2)."""
+    if key is None:
+        key_bytes = b""
+    elif isinstance(key, bytes):
+        key_bytes = key
     else:
-        return hashlib.sha256(key.encode("utf-8")).digest()
+        key_bytes = key.encode("utf-8")
+    return hashlib.pbkdf2_hmac(
+        "sha256",
+        key_bytes,
+        _API_KEY_PBKDF2_SALT,
+        _API_KEY_PBKDF2_ITERATIONS,
+    )
 
 
 def build_router(


### PR DESCRIPTION
Potential fix for [https://github.com/traoreera/xcore/security/code-scanning/21](https://github.com/traoreera/xcore/security/code-scanning/21)

In general: For secrets used like passwords (API keys, access tokens, etc.), avoid plain cryptographic hashes such as SHA-256 for verification. Instead, derive a key using a password hashing/KDF function (PBKDF2, scrypt, Argon2, bcrypt) with a fixed, sufficiently high iteration count (or other cost parameter) and compare derived keys using a constant-time comparison.

Best targeted fix here: Keep the dynamic router behavior but change `_hash_key` to use `hashlib.pbkdf2_hmac` with a fixed salt and iteration count, rather than `hashlib.sha256`. This keeps the interface (`_hash_key` returns bytes) identical, so the rest of the code (`stored_hash`, `incoming_hash`, and `hmac.compare_digest`) remains unchanged. We should also simplify the bytes-handling in `_hash_key`: the current implementation decodes bytes to str and re-encodes to utf-8; instead we can normalize the input to bytes once and then pass it to `pbkdf2_hmac`. We can define a module-level constant salt (a fixed byte string) and iteration count; since the key is passed in as `secret_key` at startup and never persisted, we don’t need per-user salts, just a stable configuration.

Concrete changes in xcore/kernel/api/router.py:

- Keep the existing `import hashlib` (we already have it).
- Add module-level constants, e.g.:

  ```python
  _API_KEY_PBKDF2_SALT = b"xcore-router-api-key-salt"
  _API_KEY_PBKDF2_ITERATIONS = 100_000
  ```

- Replace the body of `_hash_key` to:
  - Normalize `key` to `key_bytes`:
    - if `key` is `bytes`, use it as-is.
    - if `key` is `str`, encode with UTF-8.
    - if `key` is `None`, treat as empty bytes or raise; to preserve behavior and avoid new exceptions in current flow (where `key` is always provided), we can treat `None` as empty bytes.
  - Return `hashlib.pbkdf2_hmac("sha256", key_bytes, _API_KEY_PBKDF2_SALT, _API_KEY_PBKDF2_ITERATIONS)`.

This removes the direct use of `hashlib.sha256` on sensitive input and replaces it with a computationally expensive hash (PBKDF2), addressing all CodeQL variants at once while preserving the public API and existing call sites.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Strengthen API key hashing in the router by replacing direct SHA-256 use with a PBKDF2-based key derivation function.

Bug Fixes:
- Mitigate weak cryptographic hashing of API keys by using PBKDF2 with a fixed salt and iteration count instead of plain SHA-256.

Enhancements:
- Normalize API key input handling in the hashing helper to consistently support str, bytes, and None values.