### PR TITLE
Fix #45: ypo `"faild reload"` dans le message d'erreur

### DIFF
--- a/xcore/kernel/runtime/lifecycle.py
+++ b/xcore/kernel/runtime/lifecycle.py
@@ -228,7 +228,7 @@ class LifecycleManager:
             logger.info(f"[{self.manifest.name}] reloaded")
         except Exception as e:
             self._sm.transition("error")
-            raise LoadError(f"[{self.manifest.name}] faild reload : {e}") from e
+            raise LoadError(f"[{self.manifest.name}] failed reload : {e}") from e
 
     # ── Unload ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fix typo 'faild' to 'failed' in the reload error message in lifecycle.py.

## Approach

Replace the misspelled string 'faild reload' with the correct spelling 'failed reload' in the LoadError raise statement.

## Files Changed

- `xcore/kernel/runtime/lifecycle.py`

## Related Issue

Fixes #45

## Testing

No tests were added with this change. Happy to add them if needed.

## Summary by Sourcery

Bug Fixes:
- Fix a typo in the reload failure error message so it reads 'failed reload' instead of 'faild reload'.