### PR TITLE
🛡️ Sentinel: [HIGH] Fix Path Traversal in Dotenv Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The plugin installation process was vulnerable to Zip Slip (directory traversal) because it extracted files from a ZIP archive without verifying that the resolved target paths remained within the intended destination directory.
 **Learning:** Naive path concatenation using `Path` objects (`dest / member`) does not prevent traversal if the member name contains `..` components. Even if the first level is stripped, nested traversals can still occur.
 **Prevention:** Always resolve the final path and check it against the destination using `target.resolve().is_relative_to(dest.resolve())`. This ensures that even with complex relative paths or symlinks, the file will not be written outside the sandbox.
+
+## 2026-03-14 - Directory Traversal in Dotenv Injection
+**Vulnerability:** The `ManifestValidator._inject_dotenv` method allowed loading `.env` files from outside the plugin directory via the `env_file` manifest parameter.
+**Learning:** Even when using `Path` objects, concatenating a base directory with a user-provided relative path containing `..` can escape the intended directory if not explicitly validated after resolution.
+**Prevention:** Always use `.resolve()` on the final path and verify it stays within the intended base directory using `.is_relative_to(base_dir.resolve())`.

--- a/xcore/kernel/security/validation.py
+++ b/xcore/kernel/security/validation.py
@@ -116,6 +116,13 @@ class ManifestValidator:
             return
         env_file = cfg.get("env_file", ".env")
         env_path = (plugin_dir / env_file).resolve()
+
+        # Sécurité : vérifie que le fichier .env est bien dans le dossier du plugin
+        if not env_path.is_relative_to(plugin_dir.resolve()):
+            raise ManifestError(
+                f"Tentative de traversal via env_file : {env_file!r}"
+            )
+
         if not env_path.exists():
             raise ManifestError(
                 f"envconfiguration.inject=true mais '{env_path}' introuvable."


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Path Traversal in Dotenv Injection

🚨 Severity: HIGH
💡 Vulnerability: The `ManifestValidator._inject_dotenv` method was vulnerable to path traversal. A plugin manifest could specify an `env_file` path (e.g., `../../secrets.env`) that resolves outside of the plugin's own directory.
🎯 Impact: Malicious or compromised plugins could potentially load sensitive environment variables from other parts of the filesystem that they should not have access to.
🔧 Fix: Implemented a security check using `pathlib`'s `.is_relative_to()` after resolving the path to ensure the target `.env` file resides within the plugin directory.
✅ Verification: Verified using a custom test script (not committed) that confirmed traversal attempts are now blocked with a `ManifestError` while legitimate local `.env` files continue to work. Existing unit tests in `tests/unit/security/test_validation.py` were also run.

---
*PR created automatically by Jules for task [16377115515005989976](https://jules.google.com/task/16377115515005989976) started by @traoreera*

## Summary by Sourcery

Harden dotenv injection in manifest validation to prevent loading environment files outside the plugin directory and document the associated security lesson in the Sentinel security log.

Bug Fixes:
- Prevent path traversal in dotenv injection by rejecting env_file paths that resolve outside the plugin directory.

Documentation:
- Add a Sentinel security entry describing the dotenv path traversal vulnerability, its root cause, and the recommended mitigation pattern.