### PR TITLE
🛡️ Sentinel: Harden AST scanner by blocking dangerous built-in calls

### DIFF
--- a/tests/unit/security/test_validation.py
+++ b/tests/unit/security/test_validation.py
@@ -180,6 +180,9 @@ def run_command(cmd):
         bad_code = """
 def unsafe_eval(code):
     return eval(code)
+
+def unsafe_exec(code):
+    exec(code)
 """
         (temp_plugin_dir / "src" / "main.py").write_text(bad_code)
 
@@ -187,6 +190,24 @@ def unsafe_eval(code):
 
         assert result.passed is False
         assert any("eval" in err for err in result.errors)
+        assert any("exec" in err for err in result.errors)
+
+    def test_scan_forbidden_builtins(self, scanner, temp_plugin_dir):
+        """Test scanning code with forbidden built-ins."""
+        bad_code = """
+def unsafe_getattr(obj, name):
+    return getattr(obj, name)
+
+def unsafe_breakpoint():
+    breakpoint()
+"""
+        (temp_plugin_dir / "src" / "main.py").write_text(bad_code)
+
+        result = scanner.scan(temp_plugin_dir)
+
+        assert result.passed is False
+        assert any("getattr" in err for err in result.errors)
+        assert any("breakpoint" in err for err in result.errors)
 
     def test_scan_dunder_import(self, scanner, temp_plugin_dir):
         """Test scanning code with __import__."""

--- a/xcore/kernel/security/validation.py
+++ b/xcore/kernel/security/validation.py
@@ -218,6 +218,11 @@ DEFAULT_FORBIDDEN = {
     "pickle",
     "shelve",
     "marshal",
+    "getattr",
+    "setattr",
+    "delattr",
+    "hasattr",
+    "breakpoint",
 }
 
 DEFAULT_ALLOWED = {
@@ -346,8 +351,14 @@ class _ImportVisitor(ast.NodeVisitor):
             self._check(node.module, node.lineno)
 
     def visit_Call(self, node: ast.Call) -> None:
-        if isinstance(node.func, ast.Name) and node.func.id == "__import__":
-            self.errors.append(
-                f"{self.filename}:{node.lineno}: __import__() dynamique interdit"
-            )
+        if isinstance(node.func, ast.Name):
+            name = node.func.id
+            if name == "__import__":
+                self.errors.append(
+                    f"{self.path}:{node.lineno}: __import__() dynamique interdit"
+                )
+            elif name in self.forbidden:
+                self.errors.append(
+                    f"{self.path}:{node.lineno}: appel interdit : {name}()"
+                )
         self.generic_visit(node)


### PR DESCRIPTION
The AST scanner previously only blocked imports of dangerous modules but allowed direct calls to dangerous built-in functions like `eval()`, `exec()`, and `getattr()`. This change hardens the security scanner by blocking direct calls to these functions and adding more dangerous built-ins to the forbidden list. Consistency in error reporting was also improved.

---
*PR created automatically by Jules for task [14331250524431523314](https://jules.google.com/task/14331250524431523314) started by @traoreera*

## Summary by Sourcery

Harden the AST-based security scanner by treating direct calls to dangerous built-ins as forbidden and ensuring they are consistently reported as errors.

Bug Fixes:
- Block direct calls to dangerous built-in functions such as eval(), exec(), getattr(), setattr(), delattr(), hasattr(), and breakpoint() in the security scanner.

Enhancements:
- Improve error reporting consistency by using the file path and a unified message format for forbidden built-in calls.

Tests:
- Extend security validation tests to cover exec() and additional forbidden built-ins like getattr() and breakpoint().