### PR TITLE
🛡️ Sentinel: Harden AST scanner against dangerous built-ins

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `ManifestValidator._inject_dotenv` method allowed loading `.env` files from outside the plugin directory via the `env_file` manifest parameter.
 **Learning:** Even when using `Path` objects, concatenating a base directory with a user-provided relative path containing `..` can escape the intended directory if not explicitly validated after resolution.
 **Prevention:** Always use `.resolve()` on the final path and verify it stays within the intended base directory using `.is_relative_to(base_dir.resolve())`.
+
+## 2026-03-14 - Bypass of AST-based Security Controls via Built-ins
+**Vulnerability:** The `ASTScanner` was configured to forbid dangerous modules but failed to block direct calls to dangerous built-in functions like `eval()` and `exec()`, allowing sandboxed plugins to execute arbitrary code.
+**Learning:** Checking only `Import` and `ImportFrom` nodes in an AST scanner is insufficient for Python sandboxing. Dangerous built-ins can be called directly without an explicit import.
+**Prevention:** Extend `ast.NodeVisitor` to override `visit_Call` and check `node.func.id` against a comprehensive list of forbidden built-in functions (e.g., `eval`, `exec`, `getattr`, `__import__`).

--- a/tests/unit/security/test_validation.py
+++ b/tests/unit/security/test_validation.py
@@ -180,6 +180,9 @@ def run_command(cmd):
         bad_code = """
 def unsafe_eval(code):
     return eval(code)
+
+def unsafe_exec(code):
+    exec(code)
 """
         (temp_plugin_dir / "src" / "main.py").write_text(bad_code)
 
@@ -187,6 +190,24 @@ def unsafe_eval(code):
 
         assert result.passed is False
         assert any("eval" in err for err in result.errors)
+        assert any("exec" in err for err in result.errors)
+
+    def test_scan_forbidden_builtins(self, scanner, temp_plugin_dir):
+        """Test scanning code with forbidden builtins like getattr."""
+        bad_code = """
+def unsafe_getattr(obj, name):
+    return getattr(obj, name)
+
+def unsafe_setattr(obj, name, val):
+    setattr(obj, name, val)
+"""
+        (temp_plugin_dir / "src" / "main.py").write_text(bad_code)
+
+        result = scanner.scan(temp_plugin_dir)
+
+        assert result.passed is False
+        assert any("getattr" in err for err in result.errors)
+        assert any("setattr" in err for err in result.errors)
 
     def test_scan_dunder_import(self, scanner, temp_plugin_dir):
         """Test scanning code with __import__."""

--- a/xcore/kernel/security/validation.py
+++ b/xcore/kernel/security/validation.py
@@ -215,6 +215,12 @@ DEFAULT_FORBIDDEN = {
     "exec",
     "eval",
     "compile",
+    "getattr",
+    "setattr",
+    "delattr",
+    "hasattr",
+    "breakpoint",
+    "__import__",
     "pickle",
     "shelve",
     "marshal",
@@ -304,10 +310,9 @@ class ASTScanner:
             result.add_error(f"{path.name}: lecture : {e}")
             return
 
-        visitor = _ImportVisitor(
+        visitor = _SecurityVisitor(
             forbidden=self.forbidden,
             allowed=self.allowed | extra_allowed,
-            filename=path.name,
             path=path,
         )
         visitor.visit(tree)
@@ -319,14 +324,13 @@ class ASTScanner:
             result.add_warning(w)
 
 
-class _ImportVisitor(ast.NodeVisitor):
-    def __init__(self, forbidden, allowed, filename, path):
+class _SecurityVisitor(ast.NodeVisitor):
+    def __init__(self, forbidden: set[str], allowed: set[str], path: Path):
         self.forbidden = forbidden
         self.allowed = allowed
-        self.filename = filename
+        self.path = path
         self.errors: list[str] = []
         self.warnings: list[str] = []
-        self.path: Path = path
 
     def _check(self, module: str, lineno: int) -> None:
         root = module.split(".")[0]
@@ -346,8 +350,10 @@ class _ImportVisitor(ast.NodeVisitor):
             self._check(node.module, node.lineno)
 
     def visit_Call(self, node: ast.Call) -> None:
-        if isinstance(node.func, ast.Name) and node.func.id == "__import__":
-            self.errors.append(
-                f"{self.filename}:{node.lineno}: __import__() dynamique interdit"
-            )
+        if isinstance(node.func, ast.Name):
+            func_name = node.func.id
+            if func_name in self.forbidden:
+                self.errors.append(
+                    f"{self.path}:{node.lineno}: appel interdit : {func_name}()"
+                )
         self.generic_visit(node)


### PR DESCRIPTION
This change enhances the security of sandboxed plugins by strengthening the AST-based validation. Previously, the scanner only blocked dangerous imports but allowed direct calls to dangerous built-in functions like `eval()` and `exec()`.

The `ASTScanner` now inspects function calls and blocks any that use names in the `DEFAULT_FORBIDDEN` list. The internal visitor has been refactored and renamed to `_SecurityVisitor` for clarity. Comprehensive unit tests have been added to ensure these calls are correctly identified and blocked.

---
*PR created automatically by Jules for task [16140131149393239305](https://jules.google.com/task/16140131149393239305) started by @traoreera*

## Summary by Sourcery

Harden the AST-based plugin security scanner to block dangerous built-in function calls in addition to forbidden imports.

New Features:
- Detect and block calls to forbidden built-in functions during AST scanning of plugins.

Bug Fixes:
- Prevent sandboxed plugins from invoking dangerous built-ins such as eval, exec, getattr, setattr, and __import__ that previously bypassed AST import checks.

Enhancements:
- Refactor the AST import visitor into a more general _SecurityVisitor that tracks the scanned file path and validates both imports and function calls.

Documentation:
- Update Sentinel security incident log with details of the AST-based sandbox bypass and the preventive measures implemented.

Tests:
- Extend unit tests to cover detection of exec and additional forbidden built-ins like getattr and setattr.