### PR TITLE
🛡️ Sentinel: block dangerous built-in functions in AST scanner

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `ManifestValidator._inject_dotenv` method allowed loading `.env` files from outside the plugin directory via the `env_file` manifest parameter.
 **Learning:** Even when using `Path` objects, concatenating a base directory with a user-provided relative path containing `..` can escape the intended directory if not explicitly validated after resolution.
 **Prevention:** Always use `.resolve()` on the final path and verify it stays within the intended base directory using `.is_relative_to(base_dir.resolve())`.
+
+## 2025-03-20 - Blocking Dangerous Built-ins in AST Scanner
+**Vulnerability:** The `ASTScanner` was only checking for module imports and `__import__` calls, allowing plugins to use dangerous built-ins like `eval`, `exec`, `getattr`, and `setattr` to bypass security restrictions.
+**Learning:** Checking only imports is insufficient for Python security scanning because many dangerous functions are built-ins that don't require an explicit import. Call-level inspection in the AST is necessary to close these gaps.
+**Prevention:** Implement a security visitor that explicitly checks `ast.Call` nodes against a blacklist of forbidden built-in function names.

--- a/tests/unit/security/test_validation.py
+++ b/tests/unit/security/test_validation.py
@@ -201,6 +201,23 @@ def dynamic_import(module):
         assert result.passed is False
         assert any("__import__" in err for err in result.errors)
 
+    def test_scan_forbidden_builtins(self, scanner, temp_plugin_dir):
+        """Test scanning code with forbidden built-ins like getattr/setattr."""
+        bad_code = """
+def unsafe_access(obj, attr):
+    return getattr(obj, attr)
+
+def unsafe_mutation(obj, attr, val):
+    setattr(obj, attr, val)
+"""
+        (temp_plugin_dir / "src" / "main.py").write_text(bad_code)
+
+        result = scanner.scan(temp_plugin_dir)
+
+        assert result.passed is False
+        assert any("getattr" in err for err in result.errors)
+        assert any("setattr" in err for err in result.errors)
+
     def test_scan_syntax_error(self, scanner, temp_plugin_dir):
         """Test scanning code with syntax error."""
         bad_code = """

--- a/xcore/kernel/security/validation.py
+++ b/xcore/kernel/security/validation.py
@@ -212,12 +212,21 @@ DEFAULT_FORBIDDEN = {
     "dis",
     "tempfile",
     "glob",
-    "exec",
-    "eval",
-    "compile",
     "pickle",
     "shelve",
     "marshal",
+}
+
+FORBIDDEN_CALLS = {
+    "eval",
+    "exec",
+    "compile",
+    "getattr",
+    "setattr",
+    "delattr",
+    "hasattr",
+    "breakpoint",
+    "__import__",
 }
 
 DEFAULT_ALLOWED = {
@@ -304,7 +313,7 @@ class ASTScanner:
             result.add_error(f"{path.name}: lecture : {e}")
             return
 
-        visitor = _ImportVisitor(
+        visitor = _SecurityVisitor(
             forbidden=self.forbidden,
             allowed=self.allowed | extra_allowed,
             filename=path.name,
@@ -319,7 +328,7 @@ class ASTScanner:
             result.add_warning(w)
 
 
-class _ImportVisitor(ast.NodeVisitor):
+class _SecurityVisitor(ast.NodeVisitor):
     def __init__(self, forbidden, allowed, filename, path):
         self.forbidden = forbidden
         self.allowed = allowed
@@ -346,8 +355,10 @@ class _ImportVisitor(ast.NodeVisitor):
             self._check(node.module, node.lineno)
 
     def visit_Call(self, node: ast.Call) -> None:
-        if isinstance(node.func, ast.Name) and node.func.id == "__import__":
-            self.errors.append(
-                f"{self.filename}:{node.lineno}: __import__() dynamique interdit"
-            )
+        if isinstance(node.func, ast.Name):
+            func_name = node.func.id
+            if func_name in FORBIDDEN_CALLS:
+                self.errors.append(
+                    f"{self.path}:{node.lineno}: appel interdit : {func_name}()"
+                )
         self.generic_visit(node)


### PR DESCRIPTION
### 🛡️ Sentinel: Security Enhancement - AST Scanner Hardening

#### 🚨 Severity: MEDIUM

#### 💡 Vulnerability:
The `ASTScanner`, which is used to validate plugin source code (especially for sandboxed plugins), was only inspecting module imports and direct `__import__()` calls. It did not check for other dangerous Python built-in functions that do not require an import.

#### 🎯 Impact:
A malicious or poorly written plugin could use these built-ins to bypass security restrictions:
- `eval()`, `exec()`, `compile()`: Execute arbitrary code strings.
- `getattr()`, `setattr()`, `delattr()`: Access or modify internal properties and potentially escape the sandbox.
- `breakpoint()`: Suspend the execution of the server process.

#### 🔧 Fix:
1.  Enhanced the `ASTScanner` in `xcore/kernel/security/validation.py`.
2.  Renamed the internal `_ImportVisitor` to `_SecurityVisitor` to better reflect its expanded role.
3.  Updated the `visit_Call` method to check for a new blacklist of `FORBIDDEN_CALLS`.
4.  Moved `eval`, `exec`, and `compile` from `DEFAULT_FORBIDDEN` (module-based) to `FORBIDDEN_CALLS` (call-based) for more accurate detection.
5.  Added a new unit test in `tests/unit/security/test_validation.py` to ensure these calls are blocked.

#### ✅ Verification:
- Ran `PYTHONPATH=. pytest tests/unit/security/test_validation.py`.
- Verified that all 20 security validation tests pass, including the new `test_scan_forbidden_builtins`.
- Confirmed that previous tests for `eval`/`exec` and `__import__` still pass under the new logic.

---
*Sentinel's Philosophy: Defense in Depth - multiple layers of protection.*

---
*PR created automatically by Jules for task [11910745313656391483](https://jules.google.com/task/11910745313656391483) started by @traoreera*

## Summary by Sourcery

Harden the AST-based plugin security scanner by detecting calls to dangerous built-in functions rather than only inspecting imports.

New Features:
- Add support in the security AST scanner to flag calls to a set of forbidden Python built-in functions such as eval, exec, getattr, setattr, and breakpoint.

Bug Fixes:
- Prevent sandboxed plugins from bypassing security checks by invoking dangerous built-ins that previously were not detected by the AST scanner.

Enhancements:
- Rename the internal AST visitor to reflect its broadened responsibility for security checks beyond imports.
- Unify handling of forbidden function calls, including __import__, under a single call-based blacklist to improve error reporting consistency and coverage.

Documentation:
- Extend Sentinel security notes with a new entry documenting the built-in call scanning vulnerability, lessons learned, and prevention strategy.

Tests:
- Add a unit test ensuring that plugins using forbidden built-in functions like getattr and setattr are correctly rejected by the scanner.