### PR TITLE
🛡️ Sentinel: [HIGH] Fix Sandbox Escape via Dangerous Built-ins and Dunder Attributes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `ManifestValidator._inject_dotenv` method allowed loading `.env` files from outside the plugin directory via the `env_file` manifest parameter.
 **Learning:** Even when using `Path` objects, concatenating a base directory with a user-provided relative path containing `..` can escape the intended directory if not explicitly validated after resolution.
 **Prevention:** Always use `.resolve()` on the final path and verify it stays within the intended base directory using `.is_relative_to(base_dir.resolve())`.
+
+## 2025-03-20 - Sandbox Escape via Dangerous Built-ins and Dunder Attributes
+**Vulnerability:** The `ASTScanner` only blocked `__import__` calls, allowing plugins to use `eval`, `exec`, `getattr`, and access dunder attributes like `__globals__` or `__subclasses__` to escape the sandbox.
+**Learning:** Simple call-based scanning is insufficient if it doesn't cover the full range of dynamic execution and introspection capabilities in Python. Blocking just `__import__` can be bypassed by aliasing other built-ins (e.g., `e = eval; e(...)`) or using `getattr`.
+**Prevention:** Use `visit_Name` in `ast.NodeVisitor` to block access to dangerous built-ins even when not directly called, and use `visit_Attribute` to block access to sensitive introspection dunders.

--- a/tests/security/test_ast_scanner.py
+++ b/tests/security/test_ast_scanner.py
@@ -1,0 +1,68 @@
+import sys
+import os
+from pathlib import Path
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from xcore.kernel.security.validation import ASTScanner
+
+def test_ast_scanner_vulnerabilities():
+    # Create a temporary directory for the plugin
+    plugin_dir = Path("temp_test_plugin")
+    src_dir = plugin_dir / "src"
+    src_dir.mkdir(parents=True, exist_ok=True)
+
+    # Plugin source that uses dangerous functions
+    src_file = src_dir / "main.py"
+    src_file.write_text("""
+def evil_eval():
+    e = eval
+    e("import os; os.system('ls')")
+
+def evil_getattr():
+    g = getattr
+    # obj = __import__('os') # This was already blocked
+    import json
+    g(json, 'loads')('{}')
+
+def evil_dunder():
+    # Accessing __globals__ to escape sandbox
+    f = lambda: None
+    print(f.__globals__)
+""")
+
+    scanner = ASTScanner()
+    result = scanner.scan(plugin_dir)
+
+    print(f"\nScan passed: {result.passed}")
+    for error in result.errors:
+        print(f"Error: {error}")
+    for warning in result.warnings:
+        print(f"Warning: {warning}")
+
+    # Clean up
+    import shutil
+    shutil.rmtree(plugin_dir)
+
+    # After fix, result.passed should be False if dangerous code is present
+    if result.passed:
+        print("\n[!] VULNERABILITY CONFIRMED: Scanner passed dangerous code.")
+        return False
+    else:
+        print("\n[+] SUCCESS: Scanner blocked dangerous code.")
+        # Check if all 3 vulnerabilities were caught
+        error_msgs = "\n".join(result.errors)
+        if "eval" in error_msgs and "getattr" in error_msgs and "__globals__" in error_msgs:
+            print("[+] All vulnerabilities caught!")
+            return True
+        else:
+            print(f"[!] Some vulnerabilities missed: {error_msgs}")
+            return False
+
+if __name__ == "__main__":
+    success = test_ast_scanner_vulnerabilities()
+    if success:
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/xcore/kernel/security/validation.py
+++ b/xcore/kernel/security/validation.py
@@ -304,7 +304,7 @@ class ASTScanner:
             result.add_error(f"{path.name}: lecture : {e}")
             return
 
-        visitor = _ImportVisitor(
+        visitor = _SecurityVisitor(
             forbidden=self.forbidden,
             allowed=self.allowed | extra_allowed,
             filename=path.name,
@@ -319,7 +319,35 @@ class ASTScanner:
             result.add_warning(w)
 
 
-class _ImportVisitor(ast.NodeVisitor):
+class _SecurityVisitor(ast.NodeVisitor):
+    # Fonctions natives dangereuses à bloquer totalement
+    FORBIDDEN_BUILTINS = frozenset(
+        {
+            "eval",
+            "exec",
+            "compile",
+            "getattr",
+            "setattr",
+            "delattr",
+            "hasattr",
+            "breakpoint",
+            "globals",
+            "locals",
+            "__import__",
+        }
+    )
+
+    # Attributs dunders sensibles à bloquer
+    FORBIDDEN_ATTRS = frozenset(
+        {
+            "__globals__",
+            "__subclasses__",
+            "__code__",
+            "__func__",
+            "__self__",
+        }
+    )
+
     def __init__(self, forbidden, allowed, filename, path):
         self.forbidden = forbidden
         self.allowed = allowed
@@ -345,9 +373,24 @@ class _ImportVisitor(ast.NodeVisitor):
         if node.module:
             self._check(node.module, node.lineno)
 
-    def visit_Call(self, node: ast.Call) -> None:
-        if isinstance(node.func, ast.Name) and node.func.id == "__import__":
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, ast.Load) and node.id in self.FORBIDDEN_BUILTINS:
             self.errors.append(
-                f"{self.filename}:{node.lineno}: __import__() dynamique interdit"
+                f"{self.path}:{node.lineno}: utilisation interdite de {node.id!r}"
+            )
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        # Déjà couvert par visit_Name si c'est un Name,
+        # mais on garde pour la clarté ou si node.func est un Attribute complexe
+        if isinstance(node.func, ast.Name) and node.func.id in self.FORBIDDEN_BUILTINS:
+            # On évite les doublons d'erreurs si visit_Name l'a déjà vu
+            pass
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if node.attr in self.FORBIDDEN_ATTRS:
+            self.errors.append(
+                f"{self.path}:{node.lineno}: accès interdit à l'attribut {node.attr!r}"
             )
         self.generic_visit(node)


### PR DESCRIPTION
This security enhancement significantly hardens the XCore plugin sandbox by preventing common sandbox escape techniques. By blocking dangerous built-ins at the AST level, we ensure that even if a plugin is trusted, it cannot easily access the underlying system or sensitive framework internals.

Key changes:
- Renamed `_ImportVisitor` to `_SecurityVisitor` in `xcore/kernel/security/validation.py`.
- Added `FORBIDDEN_BUILTINS` and `FORBIDDEN_ATTRS` sets.
- Implemented `visit_Name` to catch forbidden built-ins even when aliased.
- Implemented `visit_Attribute` to block access to introspection dunders.
- Added a new security test suite `tests/security/test_ast_scanner.py`.

---
*PR created automatically by Jules for task [6831104716148557450](https://jules.google.com/task/6831104716148557450) started by @traoreera*

## Summary by Sourcery

Harden the XCore AST-based sandbox scanner to block additional Python sandbox escape vectors using dangerous built-ins and sensitive dunder attributes.

Bug Fixes:
- Block usage of dangerous built-in functions such as eval, exec, getattr, and __import__ during AST scanning to prevent sandbox escapes.
- Block access to sensitive introspection dunder attributes like __globals__ and __subclasses__ in plugin code.

Enhancements:
- Rename the AST visitor to a more general security-focused visitor and centralize forbidden built-ins and attributes in dedicated sets.
- Extend the AST visitor with name and attribute checks to detect forbidden constructs beyond direct function calls.
- Document the newly identified sandbox escape class and its mitigation in the Sentinel security log.

Tests:
- Add a security regression test that verifies the AST scanner rejects plugin code using dangerous built-ins and dunder attributes.