### PR TITLE
lint fixing

### DIFF
--- a/docgen/aggregator.py
+++ b/docgen/aggregator.py
@@ -8,7 +8,8 @@ def summarize_by_file(chunks, cfg):
     Groupe les chunks par fichier (path) et génère un résumé par chunk.
     Retourne un dict : path -> liste de résumés partiels + métadonnées du fichier.
     """
-    file_map = defaultdict(lambda: {"summaries": [], "module": None, "filename": None})
+    file_map = defaultdict(
+        lambda: {"summaries": [], "module": None, "filename": None})
 
     for chunk in chunks:
         path = chunk["path"]

--- a/docgen/pipeline.py
+++ b/docgen/pipeline.py
@@ -95,7 +95,8 @@ def main():
     all_modules = set(modules_files.keys()) | set(modules_children.keys())
 
     # Trier du plus profond (plus de "/" dans le chemin) au plus haut
-    sorted_modules = sorted(all_modules, key=lambda m: m.count("/"), reverse=True)
+    sorted_modules = sorted(
+        all_modules, key=lambda m: m.count("/"), reverse=True)
 
     # Stocker une description courte par module (pour les index parents)
     module_descriptions = {}

--- a/docgen/scanner.py
+++ b/docgen/scanner.py
@@ -9,7 +9,7 @@ def load_config():
 
 
 def split_content(content, max_chars):
-    return [content[i : i + max_chars] for i in range(0, len(content), max_chars)]
+    return [content[i: i + max_chars] for i in range(0, len(content), max_chars)]
 
 
 def is_excluded(root, exclude_dirs):

--- a/poetry.lock
+++ b/poetry.lock
@@ -200,6 +200,57 @@ files = [
 extras = ["regex"]
 
 [[package]]
+name = "black"
+version = "26.3.1"
+description = "The uncompromising code formatter."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "black-26.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:86a8b5035fce64f5dcd1b794cf8ec4d31fe458cf6ce3986a30deb434df82a1d2"},
+    {file = "black-26.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5602bdb96d52d2d0672f24f6ffe5218795736dd34807fd0fd55ccd6bf206168b"},
+    {file = "black-26.3.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c54a4a82e291a1fee5137371ab488866b7c86a3305af4026bdd4dc78642e1ac"},
+    {file = "black-26.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:6e131579c243c98f35bce64a7e08e87fb2d610544754675d4a0e73a070a5aa3a"},
+    {file = "black-26.3.1-cp310-cp310-win_arm64.whl", hash = "sha256:5ed0ca58586c8d9a487352a96b15272b7fa55d139fc8496b519e78023a8dab0a"},
+    {file = "black-26.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:28ef38aee69e4b12fda8dba75e21f9b4f979b490c8ac0baa7cb505369ac9e1ff"},
+    {file = "black-26.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf9bf162ed91a26f1adba8efda0b573bc6924ec1408a52cc6f82cb73ec2b142c"},
+    {file = "black-26.3.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:474c27574d6d7037c1bc875a81d9be0a9a4f9ee95e62800dab3cfaadbf75acd5"},
+    {file = "black-26.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:5e9d0d86df21f2e1677cc4bd090cd0e446278bcbbe49bf3659c308c3e402843e"},
+    {file = "black-26.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:9a5e9f45e5d5e1c5b5c29b3bd4265dcc90e8b92cf4534520896ed77f791f4da5"},
+    {file = "black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1"},
+    {file = "black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f"},
+    {file = "black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7"},
+    {file = "black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983"},
+    {file = "black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb"},
+    {file = "black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54"},
+    {file = "black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f"},
+    {file = "black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56"},
+    {file = "black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839"},
+    {file = "black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2"},
+    {file = "black-26.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78"},
+    {file = "black-26.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568"},
+    {file = "black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f"},
+    {file = "black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c"},
+    {file = "black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1"},
+    {file = "black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b"},
+    {file = "black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
+pathspec = ">=1.0.0"
+platformdirs = ">=2"
+pytokens = ">=0.4.0,<0.5.0"
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.10)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2) ; sys_platform != \"win32\"", "winloop (>=0.5.0) ; sys_platform == \"win32\""]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -1187,6 +1238,21 @@ files = [
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
+name = "isort"
+version = "8.0.1"
+description = "A Python utility / library to sort Python imports."
+optional = false
+python-versions = ">=3.10.0"
+groups = ["main"]
+files = [
+    {file = "isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75"},
+    {file = "isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d"},
+]
+
+[package.extras]
+colors = ["colorama"]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 description = "A very fast and expressive template engine."
@@ -1549,6 +1615,18 @@ python = ["mkdocstrings-python (>=1.16.2)"]
 python-legacy = ["mkdocstrings-python-legacy (>=0.2.1)"]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
+    {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
+]
+
+[[package]]
 name = "mysql-connector-python"
 version = "9.6.0"
 description = "A self-contained Python driver for communicating with MySQL servers, using an API that is compliant with the Python Database API Specification v2.0 (PEP 249)."
@@ -1623,7 +1701,7 @@ version = "26.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
     {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
@@ -1651,7 +1729,7 @@ version = "1.0.4"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723"},
     {file = "pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645"},
@@ -1790,7 +1868,7 @@ version = "4.9.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.10"
-groups = ["dev", "docs"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "platformdirs-4.9.2-py3-none-any.whl", hash = "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd"},
     {file = "platformdirs-4.9.2.tar.gz", hash = "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291"},
@@ -2205,6 +2283,61 @@ files = [
     {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
     {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
 ]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+description = "A Fast, spec compliant Python 3.14+ tokenizer that runs on older Pythons."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5"},
+    {file = "pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe"},
+    {file = "pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c"},
+    {file = "pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7"},
+    {file = "pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2"},
+    {file = "pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440"},
+    {file = "pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc"},
+    {file = "pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d"},
+    {file = "pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16"},
+    {file = "pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6"},
+    {file = "pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083"},
+    {file = "pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1"},
+    {file = "pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1"},
+    {file = "pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9"},
+    {file = "pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68"},
+    {file = "pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b"},
+    {file = "pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f"},
+    {file = "pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1"},
+    {file = "pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4"},
+    {file = "pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78"},
+    {file = "pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321"},
+    {file = "pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa"},
+    {file = "pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d"},
+    {file = "pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324"},
+    {file = "pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9"},
+    {file = "pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb"},
+    {file = "pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3"},
+    {file = "pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975"},
+    {file = "pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a"},
+    {file = "pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918"},
+    {file = "pytokens-0.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:da5baeaf7116dced9c6bb76dc31ba04a2dc3695f3d9f74741d7910122b456edc"},
+    {file = "pytokens-0.4.1-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:11edda0942da80ff58c4408407616a310adecae1ddd22eef8c692fe266fa5009"},
+    {file = "pytokens-0.4.1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0fc71786e629cef478cbf29d7ea1923299181d0699dbe7c3c0f4a583811d9fc1"},
+    {file = "pytokens-0.4.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:dcafc12c30dbaf1e2af0490978352e0c4041a7cde31f4f81435c2a5e8b9cabb6"},
+    {file = "pytokens-0.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:42f144f3aafa5d92bad964d471a581651e28b24434d184871bd02e3a0d956037"},
+    {file = "pytokens-0.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:34bcc734bd2f2d5fe3b34e7b3c0116bfb2397f2d9666139988e7a3eb5f7400e3"},
+    {file = "pytokens-0.4.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:941d4343bf27b605e9213b26bfa1c4bf197c9c599a9627eb7305b0defcfe40c1"},
+    {file = "pytokens-0.4.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3ad72b851e781478366288743198101e5eb34a414f1d5627cdd585ca3b25f1db"},
+    {file = "pytokens-0.4.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:682fa37ff4d8e95f7df6fe6fe6a431e8ed8e788023c6bcc0f0880a12eab80ad1"},
+    {file = "pytokens-0.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:30f51edd9bb7f85c748979384165601d028b84f7bd13fe14d3e065304093916a"},
+    {file = "pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de"},
+    {file = "pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a"},
+]
+
+[package.extras]
+dev = ["black", "build", "mypy", "pytest", "pytest-cov", "setuptools", "tox", "twine", "wheel"]
 
 [[package]]
 name = "pyyaml"
@@ -3277,4 +3410,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "23e14877616b8130b5e85da649f7b9e324b7bd0b0c68aa453eb8d81a84c16a21"
+content-hash = "ae9bf92d4c18756dc49c6c6ac86d746e81abff06c5d72a5a0ba1634b79b26fbf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,10 @@ setuptools = "^82.0.1"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^4.3.0"
+isort = "^8.0.1"
 black = "^26.3.1"
 flake8 = "^7.3.0"
 autoflake = "^2.3.1"
-isort = "^6.1.0"
 autopep8 = "^2.3.2"
 pytest = "^8.4.2"
 pytest-asyncio = "^1.2.0"

--- a/tests/benchmarks/test_permission_bench.py
+++ b/tests/benchmarks/test_permission_bench.py
@@ -40,7 +40,8 @@ class PermissionEngine:
 
     def load_from_manifest(self, plugin_name, raw_permissions):
         policies = [
-            Policy(p["resource"], p["actions"], PolicyEffect(p.get("effect", "allow")))
+            Policy(p["resource"], p["actions"],
+                   PolicyEffect(p.get("effect", "allow")))
             for p in raw_permissions
         ]
         self._policies[plugin_name] = PolicySet(plugin_name, policies)
@@ -97,7 +98,8 @@ def benchmark_permissions():
     permissions = [
         {"resource": "db.users.*", "actions": ["read"], "effect": "allow"},
         {"resource": "db.admin.*", "actions": ["*"], "effect": "deny"},
-        {"resource": "cache.*", "actions": ["read", "write"], "effect": "allow"},
+        {"resource": "cache.*",
+            "actions": ["read", "write"], "effect": "allow"},
         {"resource": "fs.tmp.*", "actions": ["write"], "effect": "allow"},
         {"resource": "api.v1.*", "actions": ["call"], "effect": "allow"},
     ]
@@ -122,7 +124,8 @@ def benchmark_permissions():
     t1 = timeit.Timer(lambda: run_benchmark(engine)).timeit(number=iterations)
     print(f"Original - Time for {iterations} iterations: {t1:.4f}s")
 
-    t2 = timeit.Timer(lambda: run_benchmark(engine_opt)).timeit(number=iterations)
+    t2 = timeit.Timer(lambda: run_benchmark(
+        engine_opt)).timeit(number=iterations)
     print(f"Optimized (Cached) - Time for {iterations} iterations: {t2:.4f}s")
 
     improvement = (t1 - t2) / t1 * 100

--- a/tests/benchmarks/test_permission_bench_real.py
+++ b/tests/benchmarks/test_permission_bench_real.py
@@ -12,7 +12,8 @@ def benchmark_permissions():
     permissions = [
         {"resource": "db.users.*", "actions": ["read"], "effect": "allow"},
         {"resource": "db.admin.*", "actions": ["*"], "effect": "deny"},
-        {"resource": "cache.*", "actions": ["read", "write"], "effect": "allow"},
+        {"resource": "cache.*",
+            "actions": ["read", "write"], "effect": "allow"},
         {"resource": "fs.tmp.*", "actions": ["write"], "effect": "allow"},
         {"resource": "api.v1.*", "actions": ["call"], "effect": "allow"},
         {"resource": "internal.*", "actions": ["*"], "effect": "deny"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,7 +232,8 @@ def mock_redis():
 def test_user(db_session):
     """Crée un utilisateur de test en base."""
     try:
-        from extensions.services.database import User  # adapter selon ton modèle
+        from extensions.services.database import \
+            User  # adapter selon ton modèle
         from extensions.services.security import hash_password
 
         user = User(

--- a/tests/unit/kernel/test_dynamic_middleware.py
+++ b/tests/unit/kernel/test_dynamic_middleware.py
@@ -1,8 +1,11 @@
-import pytest
 import asyncio
-from xcore.kernel.runtime.supervisor import PluginSupervisor, Middleware
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 from xcore.kernel.runtime.loader import PluginLoader
-from unittest.mock import MagicMock, AsyncMock
+from xcore.kernel.runtime.supervisor import Middleware, PluginSupervisor
+
 
 class DummyMiddleware(Middleware):
     def __init__(self, name, calls):
@@ -14,6 +17,7 @@ class DummyMiddleware(Middleware):
         res = await next_call(plugin_name, action, payload, handler, **kwargs)
         self.calls.append(f"after:{self.name}")
         return res
+
 
 @pytest.mark.asyncio
 async def test_dynamic_middleware_registration():

--- a/tests/unit/kernel/test_events_wildcard.py
+++ b/tests/unit/kernel/test_events_wildcard.py
@@ -1,7 +1,10 @@
-import pytest
 import asyncio
+
+import pytest
+
 from xcore.kernel.events.bus import EventBus
 from xcore.kernel.events.section import Event
+
 
 @pytest.mark.asyncio
 async def test_wildcard_subscription():
@@ -20,6 +23,7 @@ async def test_wildcard_subscription():
     assert "user.deleted" in received
     assert "product.created" not in received
 
+
 @pytest.mark.asyncio
 async def test_wildcard_priority():
     bus = EventBus()
@@ -37,6 +41,7 @@ async def test_wildcard_priority():
 
     assert order == ["high", "low"]
 
+
 @pytest.mark.asyncio
 async def test_wildcard_once():
     bus = EventBus()
@@ -52,6 +57,7 @@ async def test_wildcard_once():
 
     assert count == 1
     assert bus.handler_count("user.*") == 0
+
 
 @pytest.mark.asyncio
 async def test_multiple_wildcards():

--- a/tests/unit/kernel/test_lifecycle.py
+++ b/tests/unit/kernel/test_lifecycle.py
@@ -278,7 +278,8 @@ class Plugin(BasePlugin):
         await lifecycle_manager.load()
 
         results = await asyncio.gather(
-            lifecycle_manager.call("ping1", {}), lifecycle_manager.call("ping2", {})
+            lifecycle_manager.call(
+                "ping1", {}), lifecycle_manager.call("ping2", {})
         )
 
         assert len(results) == 2
@@ -465,13 +466,15 @@ class Plugin(BasePlugin):
         test_file = tmp_path / "test_module.py"
         test_file.write_text("test_var = 'hello'")
 
-        module = lifecycle_manager._import_module("test_module_import", test_file)
+        module = lifecycle_manager._import_module(
+            "test_module_import", test_file)
         assert module.test_var == "hello"
 
     def test_on_state_change(self, lifecycle_manager):
         """Test state change callback."""
         lifecycle_manager._events = MagicMock()
-        lifecycle_manager._on_state_change(PluginState.UNLOADED, PluginState.LOADING)
+        lifecycle_manager._on_state_change(
+            PluginState.UNLOADED, PluginState.LOADING)
 
         lifecycle_manager._events.emit_sync.assert_called_once()
         call_args = lifecycle_manager._events.emit_sync.call_args

--- a/tests/unit/kernel/test_lifecycle_protection.py
+++ b/tests/unit/kernel/test_lifecycle_protection.py
@@ -26,8 +26,8 @@ def mock_manifest():
 
 @pytest.mark.asyncio
 async def test_lifecycle_propagate_services_protection():
-    from xcore.registry.index import PluginRegistry
     from xcore.kernel.context import KernelContext
+    from xcore.registry.index import PluginRegistry
     shared_services = {"db": "core_db", "cache": "core_cache"}
     registry = PluginRegistry()
     # Register "db" as a core service in the registry to protect it

--- a/tests/unit/kernel/test_middleware_compiled.py
+++ b/tests/unit/kernel/test_middleware_compiled.py
@@ -1,7 +1,11 @@
 
-import pytest
 from unittest.mock import MagicMock
-from xcore.kernel.runtime.middlewares.middleware import Middleware, MiddlewarePipeline
+
+import pytest
+
+from xcore.kernel.runtime.middlewares.middleware import (Middleware,
+                                                         MiddlewarePipeline)
+
 
 class MockMiddleware(Middleware):
     def __init__(self, name):
@@ -11,6 +15,7 @@ class MockMiddleware(Middleware):
     async def __call__(self, plugin_name, action, payload, next_call, handler, **kwargs):
         self.calls.append((plugin_name, action, payload))
         return await next_call(plugin_name, action, payload, handler, **kwargs)
+
 
 @pytest.mark.asyncio
 async def test_compiled_pipeline_execution_order():
@@ -30,6 +35,7 @@ async def test_compiled_pipeline_execution_order():
     assert mw1.calls == [("plugin", "action", {"data": 1})]
     assert mw2.calls == [("plugin", "action", {"data": 1})]
 
+
 @pytest.mark.asyncio
 async def test_compiled_pipeline_handler_propagation():
     received_handlers = []
@@ -40,6 +46,7 @@ async def test_compiled_pipeline_handler_propagation():
             return await next_call(plugin_name, action, payload, handler, **kwargs)
 
     mw = HandlerTrackingMiddleware()
+
     async def final_handler(p, a, pay, handler, **kwargs):
         received_handlers.append(handler)
         return {"status": "ok"}

--- a/tests/unit/kernel/test_permissions.py
+++ b/tests/unit/kernel/test_permissions.py
@@ -10,7 +10,8 @@ class TestPermissionEngine:
         return PermissionEngine()
 
     def test_load_and_check(self, engine):
-        permissions = [{"resource": "db.*", "actions": ["read"], "effect": "allow"}]
+        permissions = [{"resource": "db.*",
+                        "actions": ["read"], "effect": "allow"}]
         engine.load_from_manifest("test_plugin", permissions)
 
         # Should allow
@@ -23,7 +24,8 @@ class TestPermissionEngine:
         assert engine.allows("test_plugin", "db.users", "write") is False
 
     def test_memoization(self, engine):
-        permissions = [{"resource": "db.*", "actions": ["read"], "effect": "allow"}]
+        permissions = [{"resource": "db.*",
+                        "actions": ["read"], "effect": "allow"}]
         engine.load_from_manifest("test_plugin", permissions)
 
         # First call, populates cache
@@ -43,7 +45,8 @@ class TestPermissionEngine:
         assert engine.allows("test_plugin", "db.users", "read") is False
 
     def test_cache_invalidation_load(self, engine):
-        permissions = [{"resource": "db.*", "actions": ["read"], "effect": "allow"}]
+        permissions = [{"resource": "db.*",
+                        "actions": ["read"], "effect": "allow"}]
         engine.load_from_manifest("test_plugin", permissions)
         engine.allows("test_plugin", "db.users", "read")
         assert len(engine._cache) > 0
@@ -53,7 +56,8 @@ class TestPermissionEngine:
 
     def test_cache_invalidation_grant_all(self, engine):
         engine.load_from_manifest(
-            "test_plugin", [{"resource": "db.*", "actions": ["read"], "effect": "deny"}]
+            "test_plugin", [{"resource": "db.*",
+                             "actions": ["read"], "effect": "deny"}]
         )
         engine.allows("test_plugin", "db.users", "read")
         assert len(engine._cache) > 0

--- a/tests/unit/kernel/test_policies.py
+++ b/tests/unit/kernel/test_policies.py
@@ -66,7 +66,8 @@ class TestPolicy:
 
     def test_from_dict_basic(self):
         """Test from_dict with basic data."""
-        data = {"resource": "db.*", "actions": ["read", "write"], "effect": "allow"}
+        data = {"resource": "db.*",
+                "actions": ["read", "write"], "effect": "allow"}
         policy = Policy.from_dict(data)
         assert policy.resource == "db.*"
         assert policy.actions == ["read", "write"]
@@ -100,9 +101,12 @@ class TestPolicySet:
     def sample_policies(self):
         """Create sample policies."""
         return [
-            Policy(resource="db.*", actions=["read"], effect=PolicyEffect.ALLOW),
-            Policy(resource="db.*", actions=["write"], effect=PolicyEffect.DENY),
-            Policy(resource="cache.*", actions=["*"], effect=PolicyEffect.ALLOW),
+            Policy(resource="db.*",
+                   actions=["read"], effect=PolicyEffect.ALLOW),
+            Policy(resource="db.*",
+                   actions=["write"], effect=PolicyEffect.DENY),
+            Policy(resource="cache.*",
+                   actions=["*"], effect=PolicyEffect.ALLOW),
         ]
 
     def test_creation(self, sample_policies):
@@ -174,7 +178,8 @@ class TestPolicySet:
     def test_to_list(self):
         """Test to_list serialization."""
         policies = [
-            Policy(resource="db.*", actions=["read"], effect=PolicyEffect.ALLOW),
+            Policy(resource="db.*",
+                   actions=["read"], effect=PolicyEffect.ALLOW),
         ]
         ps = PolicySet(plugin_name="test", policies=policies)
         result = ps.to_list()
@@ -205,7 +210,8 @@ class TestPolicySetEdgeCases:
         """Test that policy order affects evaluation."""
         # More specific policy first
         policies_ordered = [
-            Policy(resource="db.users", actions=["read"], effect=PolicyEffect.ALLOW),
+            Policy(resource="db.users", actions=[
+                   "read"], effect=PolicyEffect.ALLOW),
             Policy(resource="db.*", actions=["*"], effect=PolicyEffect.DENY),
         ]
         ps = PolicySet(plugin_name="test", policies=policies_ordered)
@@ -215,7 +221,8 @@ class TestPolicySetEdgeCases:
     def test_partial_wildcard_match(self):
         """Test partial wildcard in resource."""
         policies = [
-            Policy(resource="db.*.read", actions=["*"], effect=PolicyEffect.ALLOW),
+            Policy(resource="db.*.read",
+                   actions=["*"], effect=PolicyEffect.ALLOW),
         ]
         ps = PolicySet(plugin_name="test", policies=policies)
         assert ps.allows("db.users.read", "anything") is True
@@ -224,7 +231,8 @@ class TestPolicySetEdgeCases:
     def test_complex_wildcard_pattern(self):
         """Test complex wildcard patterns."""
         policies = [
-            Policy(resource="db.user*.*", actions=["read"], effect=PolicyEffect.ALLOW),
+            Policy(resource="db.user*.*",
+                   actions=["read"], effect=PolicyEffect.ALLOW),
         ]
         ps = PolicySet(plugin_name="test", policies=policies)
         assert ps.allows("db.user1.profile", "read") is True

--- a/tests/unit/kernel/test_ratelimit.py
+++ b/tests/unit/kernel/test_ratelimit.py
@@ -2,12 +2,9 @@ import time
 
 import pytest
 
-from xcore.kernel.sandbox.limits import (
-    RateLimitConfig,
-    RateLimiter,
-    RateLimiterRegistry,
-    RateLimitExceeded,
-)
+from xcore.kernel.sandbox.limits import (RateLimitConfig, RateLimiter,
+                                         RateLimiterRegistry,
+                                         RateLimitExceeded)
 
 
 def test_ratelimiter_basic():

--- a/tests/unit/kernel/test_registry_protection_new.py
+++ b/tests/unit/kernel/test_registry_protection_new.py
@@ -1,5 +1,7 @@
 import pytest
+
 from xcore.registry.index import PluginRegistry
+
 
 def test_protected_service_protection():
     registry = PluginRegistry()
@@ -12,12 +14,14 @@ def test_protected_service_protection():
 
     # 3. Attempt to overwrite from a plugin
     with pytest.raises(PermissionError) as excinfo:
-        registry.register_service("malicious_plugin", "db", {"info": "fake_db"})
+        registry.register_service(
+            "malicious_plugin", "db", {"info": "fake_db"})
 
     assert "Impossible d'écraser le service protégé 'db'" in str(excinfo.value)
 
     # 4. Verify the original service is still there
     assert registry.get_service("db")["info"] == "real_db"
+
 
 def test_public_service_overwrite():
     registry = PluginRegistry()

--- a/tests/unit/kernel/test_sandbox_worker.py
+++ b/tests/unit/kernel/test_sandbox_worker.py
@@ -11,13 +11,9 @@ from unittest.mock import patch
 import pytest
 
 # Test the components we can import
-from xcore.kernel.sandbox.worker import (
-    FilesystemGuard,
-    _apply_memory_limit,
-    _load_manifest,
-    _PluginImportHook,
-    _PluginManifest,
-)
+from xcore.kernel.sandbox.worker import (FilesystemGuard, _apply_memory_limit,
+                                         _load_manifest, _PluginImportHook,
+                                         _PluginManifest)
 
 
 class TestPluginManifest:
@@ -68,7 +64,8 @@ class TestApplyMemoryLimit:
                     mock_setrlimit.assert_called_once()
                     # Check the limit is 100MB in bytes
                     call_args = mock_setrlimit.call_args
-                    assert call_args[0][1] == (100 * 1024 * 1024, 100 * 1024 * 1024)
+                    assert call_args[0][1] == (
+                        100 * 1024 * 1024, 100 * 1024 * 1024)
 
 
 class TestFilesystemGuard:
@@ -291,7 +288,8 @@ class TestFilesystemGuardEdgeCases:
 
     def test_empty_allowed_paths(self, tmp_path):
         """Test guard with empty allowed paths."""
-        guard = FilesystemGuard(plugin_dir=tmp_path, allowed_paths=[], denied_paths=[])
+        guard = FilesystemGuard(plugin_dir=tmp_path,
+                                allowed_paths=[], denied_paths=[])
         # With no allowed paths, everything should be denied (fail-closed)
         assert guard.is_allowed(tmp_path / "any/file.txt") is False
 

--- a/tests/unit/kernel/test_state_machine.py
+++ b/tests/unit/kernel/test_state_machine.py
@@ -4,11 +4,8 @@ Tests for StateMachine.
 
 import pytest
 
-from xcore.kernel.runtime.state_machine import (
-    InvalidTransition,
-    PluginState,
-    StateMachine,
-)
+from xcore.kernel.runtime.state_machine import (InvalidTransition, PluginState,
+                                                StateMachine)
 
 
 class TestPluginState:

--- a/tests/unit/plugins/test_base.py
+++ b/tests/unit/plugins/test_base.py
@@ -5,12 +5,8 @@ Tests for plugin base classes and SDK.
 import pytest
 
 from xcore.kernel.api.contract import ExecutionMode
-from xcore.sdk.plugin_base import (
-    PluginManifest,
-    RateLimitConfig,
-    ResourceConfig,
-    RuntimeConfig,
-)
+from xcore.sdk.plugin_base import (PluginManifest, RateLimitConfig,
+                                   ResourceConfig, RuntimeConfig)
 
 
 class TestRateLimitConfig:

--- a/tests/unit/plugins/test_decorators.py
+++ b/tests/unit/plugins/test_decorators.py
@@ -7,16 +7,9 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from xcore.sdk.decorators import (
-    AutoDispatchMixin,
-    RoutedPlugin,
-    action,
-    require_service,
-    route,
-    sandboxed,
-    trusted,
-    validate_payload,
-)
+from xcore.sdk.decorators import (AutoDispatchMixin, RoutedPlugin, action,
+                                  require_service, route, sandboxed, trusted,
+                                  validate_payload)
 
 
 class TestActionDecorator:
@@ -176,7 +169,8 @@ class TestRequireServiceDecorator:
         plugin = Plugin()
 
         assert hasattr(plugin.my_action, "_requires_services")
-        assert plugin.my_action._requires_services == ["db", "cache", "scheduler"]
+        assert plugin.my_action._requires_services == [
+            "db", "cache", "scheduler"]
 
 
 class TestValidatePayloadDecorator:

--- a/tests/unit/security/test_ast_bypass.py
+++ b/tests/unit/security/test_ast_bypass.py
@@ -3,11 +3,9 @@ from pathlib import Path
 
 import pytest
 
-from xcore.kernel.security.validation import (
-    DEFAULT_ALLOWED,
-    DEFAULT_FORBIDDEN,
-    _SecurityVisitor,
-)
+from xcore.kernel.security.validation import (DEFAULT_ALLOWED,
+                                              DEFAULT_FORBIDDEN,
+                                              _SecurityVisitor)
 
 
 class TestASTBypass:

--- a/tests/unit/security/test_ast_scanner.py
+++ b/tests/unit/security/test_ast_scanner.py
@@ -8,16 +8,11 @@ from unittest.mock import patch
 
 import pytest
 
-from xcore.kernel.security.validation import (
-    DEFAULT_ALLOWED,
-    DEFAULT_FORBIDDEN,
-    ASTScanner,
-    ManifestError,
-    ManifestValidator,
-    ScanResult,
-    _resolve_env,
-    _SecurityVisitor,
-)
+from xcore.kernel.security.validation import (DEFAULT_ALLOWED,
+                                              DEFAULT_FORBIDDEN, ASTScanner,
+                                              ManifestError, ManifestValidator,
+                                              ScanResult, _resolve_env,
+                                              _SecurityVisitor)
 
 
 class TestScanResult:
@@ -54,7 +49,8 @@ class TestScanResult:
 
     def test_str_failed(self):
         """Test __str__ when failed."""
-        result = ScanResult(passed=False, errors=["Error 1"], warnings=["Warning 1"])
+        result = ScanResult(passed=False, errors=[
+                            "Error 1"], warnings=["Warning 1"])
         result_str = str(result)
         assert "❌" in result_str
         assert "Error 1" in result_str
@@ -376,14 +372,16 @@ description: Test description
     def test_inject_dotenv_missing_file(self, validator, tmp_path):
         """Test _inject_dotenv with missing file."""
         with pytest.raises(ManifestError) as exc_info:
-            validator._inject_dotenv({"inject": True, "env_file": ".env"}, tmp_path)
+            validator._inject_dotenv(
+                {"inject": True, "env_file": ".env"}, tmp_path)
 
         assert "introuvable" in str(exc_info.value)
 
     def test_inject_dotenv_path_traversal(self, validator, tmp_path):
         """Test _inject_dotenv blocks path traversal."""
         with pytest.raises(ManifestError) as exc_info:
-            validator._inject_dotenv({"inject": True, "env_file": "../.env"}, tmp_path)
+            validator._inject_dotenv(
+                {"inject": True, "env_file": "../.env"}, tmp_path)
 
         assert "traversal" in str(exc_info.value)
 

--- a/tests/unit/security/test_sentinel_fixes.py
+++ b/tests/unit/security/test_sentinel_fixes.py
@@ -1,7 +1,10 @@
 import ast
 from pathlib import Path
+
 import pytest
+
 from xcore.kernel.security.validation import ASTScanner
+
 
 def test_ast_scanner_blocks_new_forbidden_builtins(tmp_path):
     src_dir = tmp_path / "src"
@@ -25,6 +28,7 @@ def leak_info():
     assert "utilisation de built-in interdit : 'vars'" in error_msgs
     assert "utilisation de built-in interdit : 'input'" in error_msgs
     assert "utilisation de built-in interdit : 'help'" in error_msgs
+
 
 def test_ast_scanner_blocks_new_forbidden_modules(tmp_path):
     src_dir = tmp_path / "src"

--- a/tests/unit/security/test_signature_bypass.py
+++ b/tests/unit/security/test_signature_bypass.py
@@ -1,9 +1,13 @@
 
-import pytest
-from pathlib import Path
 import json
+from pathlib import Path
+
+import pytest
 import yaml
-from xcore.kernel.security.signature import sign_plugin, verify_plugin, SignatureError
+
+from xcore.kernel.security.signature import (SignatureError, sign_plugin,
+                                             verify_plugin)
+
 
 class MockManifest:
     def __init__(self, name, version, plugin_dir, entry_point="src/main.py"):
@@ -11,6 +15,7 @@ class MockManifest:
         self.version = version
         self.plugin_dir = Path(plugin_dir)
         self.entry_point = entry_point
+
 
 def test_signature_bypass_outside_src(tmp_path):
     """
@@ -37,7 +42,8 @@ def test_signature_bypass_outside_src(tmp_path):
     }
     (plugin_dir / "plugin.yaml").write_text(yaml.dump(manifest_data))
 
-    manifest = MockManifest("my_plugin", "1.0.0", plugin_dir, entry_point="app/main.py")
+    manifest = MockManifest("my_plugin", "1.0.0",
+                            plugin_dir, entry_point="app/main.py")
     secret_key = b"secret"
 
     # Sign the plugin
@@ -55,6 +61,7 @@ def test_signature_bypass_outside_src(tmp_path):
     with pytest.raises(SignatureError):
         verify_plugin(manifest, secret_key)
 
+
 def test_signature_root_entry_point(tmp_path):
     """
     Test that modifying code at the root can bypass signature verification
@@ -71,7 +78,8 @@ def test_signature_root_entry_point(tmp_path):
     root_main = plugin_dir / "main.py"
     root_main.write_text("print('Safe root code')")
 
-    manifest = MockManifest("root_plugin", "1.0.0", plugin_dir, entry_point="main.py")
+    manifest = MockManifest("root_plugin", "1.0.0",
+                            plugin_dir, entry_point="main.py")
     secret_key = b"secret"
 
     # Sign
@@ -83,6 +91,7 @@ def test_signature_root_entry_point(tmp_path):
 
     try:
         verify_plugin(manifest, secret_key)
-        pytest.fail("Signature verification should have failed after modifying code at root!")
+        pytest.fail(
+            "Signature verification should have failed after modifying code at root!")
     except SignatureError:
         pass

--- a/tests/unit/security/test_validation.py
+++ b/tests/unit/security/test_validation.py
@@ -8,12 +8,8 @@ from pathlib import Path
 import pytest
 
 from xcore.kernel.api.contract import ExecutionMode
-from xcore.kernel.security.validation import (
-    ASTScanner,
-    ManifestError,
-    ManifestValidator,
-    ScanResult,
-)
+from xcore.kernel.security.validation import (ASTScanner, ManifestError,
+                                              ManifestValidator, ScanResult)
 
 
 class TestManifestValidator:

--- a/tests/unit/services/test_container.py
+++ b/tests/unit/services/test_container.py
@@ -10,13 +10,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from xcore.services.base import BaseService, BaseServiceProvider, ServiceStatus
-from xcore.services.container import (
-    CacheServiceProvider,
-    DatabaseServiceProvider,
-    ExtensionServiceProvider,
-    SchedulerServiceProvider,
-    ServiceContainer,
-)
+from xcore.services.container import (CacheServiceProvider,
+                                      DatabaseServiceProvider,
+                                      ExtensionServiceProvider,
+                                      SchedulerServiceProvider,
+                                      ServiceContainer)
 
 
 # Mock service classes for testing
@@ -225,7 +223,8 @@ class TestServiceContainer:
     async def test_health_with_failing_service(self, container):
         """Test health check with failing service."""
         service = MockService()
-        service.health_check = AsyncMock(return_value=(False, "Connection failed"))
+        service.health_check = AsyncMock(
+            return_value=(False, "Connection failed"))
         container._services["test"] = service
 
         result = await container.health()
@@ -237,7 +236,8 @@ class TestServiceContainer:
     async def test_health_exception(self, container):
         """Test health check when service raises exception."""
         service = MockService()
-        service.health_check = AsyncMock(side_effect=Exception("Health check failed"))
+        service.health_check = AsyncMock(
+            side_effect=Exception("Health check failed"))
         container._services["test"] = service
 
         result = await container.health()

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -8,7 +8,8 @@ import pytest
 import yaml
 
 from xcore.configurations.loader import ConfigLoader
-from xcore.configurations.sections import AppConfig, PluginConfig, ServicesConfig
+from xcore.configurations.sections import (AppConfig, PluginConfig,
+                                           ServicesConfig)
 
 
 class TestConfigLoader:

--- a/tests/unit/test_registry_new.py
+++ b/tests/unit/test_registry_new.py
@@ -42,7 +42,8 @@ def test_registry_service_scoping():
     )
 
     # Access by owner should work
-    assert registry.get_service("private_svc", requester="plugin1") == {"secret": 123}
+    assert registry.get_service("private_svc", requester="plugin1") == {
+        "secret": 123}
 
     # Access by others should fail
     with pytest.raises(PermissionError):

--- a/xcore/__init__.py
+++ b/xcore/__init__.py
@@ -21,13 +21,8 @@ from .__version__ import __version__
 from .kernel.api.contract import BasePlugin, TrustedBase
 from .kernel.events.bus import EventBus
 from .kernel.events.hooks import HookManager
-from .kernel.observability import (
-    HealthChecker,
-    MetricsRegistry,
-    Tracer,
-    configure_logging,
-    get_logger,
-)
+from .kernel.observability import (HealthChecker, MetricsRegistry, Tracer,
+                                   configure_logging, get_logger)
 from .kernel.runtime.lifecycle import LifecycleManager
 from .kernel.runtime.loader import PluginLoader
 from .kernel.runtime.supervisor import PluginSupervisor
@@ -212,6 +207,13 @@ class Xcore:
             self._logger.info(
                 f"[{plugin_name}] 🌐 {n_routes} route(s) montée(s) "
                 f"sous {wrapper.prefix}"
+            )
+
+        for middleware in self.plugins.collect_middlewares():
+            app.add_middleware(
+                middleware.get("middleware", middleware.get(
+                    "handler", lambda: None)),
+                **middleware.get("params", middleware.get("option", {})),
             )
 
         app.openapi_schema = None  # force la regen du schéma OpenAPI

--- a/xcore/cli/main.py
+++ b/xcore/cli/main.py
@@ -40,7 +40,8 @@ def main() -> None:
         prog="xcore",
         description="xcore v2 — gestion du framework plugin-first",
     )
-    parser.add_argument("--config", default=None, help="Chemin vers xcore.yaml")
+    parser.add_argument("--config", default=None,
+                        help="Chemin vers xcore.yaml")
     parser.add_argument("--version", action="store_true")
 
     subparsers = parser.add_subparsers(dest="command")
@@ -98,19 +99,22 @@ def main() -> None:
         default="marketplace",
         help="Source d'installation (défaut: marketplace)",
     )
-    install_p.add_argument("--url", default=None, help="URL directe (zip ou git)")
+    install_p.add_argument("--url", default=None,
+                           help="URL directe (zip ou git)")
 
     remove_p = plugin_sub.add_parser("remove", help="Supprime un plugin")
     remove_p.add_argument("name")
 
-    info_p = plugin_sub.add_parser("info", help="Affiche les métadonnées d'un plugin")
+    info_p = plugin_sub.add_parser(
+        "info", help="Affiche les métadonnées d'un plugin")
     info_p.add_argument("name")
 
     sign_p = plugin_sub.add_parser("sign", help="Signe un plugin Trusted")
     sign_p.add_argument("path")
     sign_p.add_argument("--key", default=None)
 
-    verify_p = plugin_sub.add_parser("verify", help="Vérifie la signature d'un plugin")
+    verify_p = plugin_sub.add_parser(
+        "verify", help="Vérifie la signature d'un plugin")
     verify_p.add_argument("path")
     verify_p.add_argument("--key", default=None)
 
@@ -120,10 +124,12 @@ def main() -> None:
     validate_p.add_argument("path")
 
     # ── sandbox ───────────────────────────────────────────────
-    sandbox_p = subparsers.add_parser("sandbox", help="Gestion du sandbox runtime")
+    sandbox_p = subparsers.add_parser(
+        "sandbox", help="Gestion du sandbox runtime")
     sandbox_sub = sandbox_p.add_subparsers(dest="subcommand")
 
-    sb_run = sandbox_sub.add_parser("run", help="Lance un plugin en mode sandbox isolé")
+    sb_run = sandbox_sub.add_parser(
+        "run", help="Lance un plugin en mode sandbox isolé")
     sb_run.add_argument("name", help="Nom du plugin")
 
     sb_limits = sandbox_sub.add_parser(
@@ -156,13 +162,15 @@ def main() -> None:
 
     mkt_rate = mkt_sub.add_parser("rate", help="Note un plugin")
     mkt_rate.add_argument("name")
-    mkt_rate.add_argument("--score", type=int, choices=range(1, 6), required=True)
+    mkt_rate.add_argument("--score", type=int,
+                          choices=range(1, 6), required=True)
 
     # ── services ──────────────────────────────────────────────
     svc_p = subparsers.add_parser("services", help="État des services")
     svc_sub = svc_p.add_subparsers(dest="subcommand")
     svc_status_p = svc_sub.add_parser("status")
-    svc_status_p.add_argument("--json", action="store_true", help="Output as JSON")
+    svc_status_p.add_argument(
+        "--json", action="store_true", help="Output as JSON")
 
     health_p = subparsers.add_parser("health", help="Health check global")
     health_p.add_argument("--json", action="store_true", help="Output as JSON")

--- a/xcore/cli/marketplace_cmd.py
+++ b/xcore/cli/marketplace_cmd.py
@@ -73,8 +73,10 @@ async def _mkt_list(args) -> None:
     table.add_column(
         "Nom", style="cyan", no_wrap=True, max_width=32, overflow="ellipsis"
     )
-    table.add_column("Version", style="magenta", max_width=16, overflow="ellipsis")
-    table.add_column("Auteur", style="green", max_width=24, overflow="ellipsis")
+    table.add_column("Version", style="magenta",
+                     max_width=16, overflow="ellipsis")
+    table.add_column("Auteur", style="green",
+                     max_width=24, overflow="ellipsis")
     table.add_column("Note")
     table.add_column("Description", style="white")
 
@@ -186,7 +188,8 @@ async def _mkt_show(args) -> None:
             sys.exit(1)
 
     if not plugin:
-        error_console.print(f"[bold red]❌ Plugin '{escape(name)}' introuvable.[/]")
+        error_console.print(
+            f"[bold red]❌ Plugin '{escape(name)}' introuvable.[/]")
         sys.exit(1)
 
     info = [
@@ -212,7 +215,8 @@ async def _mkt_show(args) -> None:
 
     content += f"\n[italic grey70]Pour installer :[/]\n  [bold]xcore plugin install {escape(name)}[/]"
     title = f"[bold green]📦 {escape(plugin.get('name', name))} v{escape(str(plugin.get('version', '?')))}[/]"
-    console.print(Panel(content, title=title, expand=False, border_style="cyan"))
+    console.print(Panel(content, title=title,
+                  expand=False, border_style="cyan"))
 
 
 # ── rate ──────────────────────────────────────────────────────

--- a/xcore/cli/plugin_cmd.py
+++ b/xcore/cli/plugin_cmd.py
@@ -78,7 +78,8 @@ async def _plugin_list(args) -> None:
     cfg = _load_config(args)
     plugin_dir = Path(cfg.plugins.directory)
     if not plugin_dir.exists():
-        console.print(f"[bold red]❌ Dossier plugins introuvable :[/] {plugin_dir}")
+        console.print(
+            f"[bold red]❌ Dossier plugins introuvable :[/] {plugin_dir}")
         return
     plugins = sorted(
         d.name
@@ -108,7 +109,8 @@ async def _plugin_list(args) -> None:
                 desc = m.get("description", "")
                 table.add_row(p, f"v{version}", mode, desc)
             except Exception:
-                table.add_row(p, "[red]?[/]", "[red]?[/]", "[red]Erreur de lecture[/]")
+                table.add_row(p, "[red]?[/]", "[red]?[/]",
+                              "[red]Erreur de lecture[/]")
         else:
             table.add_row(
                 p,
@@ -127,7 +129,8 @@ async def _plugin_health(args) -> None:
     cfg = _load_config(args)
     plugin_dir = Path(cfg.plugins.directory)
     if not plugin_dir.exists():
-        console.print(f"[bold red]❌ Dossier plugins introuvable :[/] {plugin_dir}")
+        console.print(
+            f"[bold red]❌ Dossier plugins introuvable :[/] {plugin_dir}")
         return
 
     plugins = sorted(
@@ -220,7 +223,8 @@ async def _plugin_install(args) -> None:
 
     elif source == "zip" or (url and (url.endswith(".zip") or url.startswith("http"))):
         if not url:
-            console.print(f"[bold red]❌ Erreur :[/] --url requis pour --source zip")
+            console.print(
+                f"[bold red]❌ Erreur :[/] --url requis pour --source zip")
             sys.exit(1)
         await _install_from_zip(name, url, dest)
 
@@ -252,7 +256,8 @@ async def _install_from_git(name: str, url: str, dest: Path) -> None:
     )
     _, stderr = await proc.communicate()
     if proc.returncode != 0:
-        console.print(f"[bold red]❌ git clone échoué :[/] {stderr.decode().strip()}")
+        console.print(
+            f"[bold red]❌ git clone échoué :[/] {stderr.decode().strip()}")
         sys.exit(1)
 
 
@@ -272,14 +277,15 @@ async def _install_from_zip(name: str, url: str, dest: Path) -> None:
         with zipfile.ZipFile(io.BytesIO(data)) as zf:
             # Détecte un sous-dossier racine dans le zip
             members = zf.namelist()
-            prefix = members[0].split("/")[0] + "/" if "/" in members[0] else ""
+            prefix = members[0].split(
+                "/")[0] + "/" if "/" in members[0] else ""
 
             dest_resolved = dest.resolve()
             dest_resolved.mkdir(parents=True, exist_ok=True)
 
             for member in members:
                 stripped = (
-                    member[len(prefix) :]
+                    member[len(prefix):]
                     if prefix and member.startswith(prefix)
                     else member
                 )
@@ -372,7 +378,8 @@ async def _plugin_remove(args) -> None:
         )
         sys.exit(1)
 
-    confirm = Confirm.ask(f"[bold red]⚠️  Supprimer '{name}' ?[/]", default=False)
+    confirm = Confirm.ask(
+        f"[bold red]⚠️  Supprimer '{name}' ?[/]", default=False)
     if not confirm:
         console.print("Annulé.")
         return
@@ -436,7 +443,8 @@ async def _plugin_info(args) -> None:
 
     # Permissions
     if manifest.permissions:
-        info.append(f"\n[bold white]Permissions ({len(manifest.permissions)}) :[/]")
+        info.append(
+            f"\n[bold white]Permissions ({len(manifest.permissions)}) :[/]")
         for p in manifest.permissions:
             effect = p.get("effect", "allow")
             symbol = "✅" if effect == "allow" else "❌"
@@ -446,7 +454,8 @@ async def _plugin_info(args) -> None:
 
     content = Group(*info)
     title = f"[bold green]🔌 {escape(manifest.name)} v{escape(manifest.version)}[/]"
-    console.print(Panel(content, title=title, expand=False, border_style="cyan"))
+    console.print(Panel(content, title=title,
+                  expand=False, border_style="cyan"))
 
 
 # ── sign / verify / validate ──────────────────────────────────
@@ -633,7 +642,8 @@ async def handle_services(args) -> None:
                 color = "orange1"
 
             # On retire les clés déjà affichées dans les colonnes
-            details = {k: v for k, v in info.items() if k not in ("name", "status")}
+            details = {k: v for k, v in info.items(
+            ) if k not in ("name", "status")}
             details_str = ", ".join(f"{k}={v}" for k, v in details.items())
 
             table.add_row(
@@ -645,7 +655,8 @@ async def handle_services(args) -> None:
         console.print(table)
         if status.get("registered_keys"):
             keys = ", ".join(status["registered_keys"])
-            console.print(f"\n[bold cyan]Clés enregistrées :[/] [dim]{escape(keys)}[/]")
+            console.print(
+                f"\n[bold cyan]Clés enregistrées :[/] [dim]{escape(keys)}[/]")
 
 
 async def handle_health(args) -> None:

--- a/xcore/cli/sandbox_cmd.py
+++ b/xcore/cli/sandbox_cmd.py
@@ -62,7 +62,8 @@ async def _sandbox_run(args) -> None:
     plugin_dir = Path(cfg.plugins.directory) / name
 
     if not plugin_dir.is_dir():
-        print(f"❌  Plugin '{name}' introuvable : {plugin_dir}", file=sys.stderr)
+        print(
+            f"❌  Plugin '{name}' introuvable : {plugin_dir}", file=sys.stderr)
         sys.exit(1)
 
     try:
@@ -71,17 +72,16 @@ async def _sandbox_run(args) -> None:
         print(f"❌  Manifeste invalide : {e}", file=sys.stderr)
         sys.exit(1)
 
-    from xcore.kernel.sandbox.process_manager import (
-        SandboxConfig,
-        SandboxProcessManager,
-    )
+    from xcore.kernel.sandbox.process_manager import (SandboxConfig,
+                                                      SandboxProcessManager)
 
     info = [
         f"[bold cyan]Mémoire max :[/][magenta] {manifest.resources.max_memory_mb}MB[/]",
         f"[bold cyan]Timeout     :[/][magenta] {manifest.resources.timeout_seconds}s[/]",
     ]
     title = f"[bold green]🚀 Lancement sandbox : {escape(name)}[/]"
-    console.print(Panel(Group(*info), title=title, expand=False, border_style="cyan"))
+    console.print(Panel(Group(*info), title=title,
+                  expand=False, border_style="cyan"))
 
     config = SandboxConfig(
         timeout=manifest.resources.timeout_seconds,
@@ -146,7 +146,8 @@ async def _sandbox_limits(args) -> None:
     try:
         manifest = _load_manifest(plugin_dir)
     except Exception as e:
-        error_console.print(f"[bold red]❌ Manifeste invalide :[/] {escape(str(e))}")
+        error_console.print(
+            f"[bold red]❌ Manifeste invalide :[/] {escape(str(e))}")
         sys.exit(1)
 
     r = manifest.resources
@@ -162,14 +163,17 @@ async def _sandbox_limits(args) -> None:
     ]
 
     if rt.health_check.enabled:
-        info.append(f"    [dim]intervalle     : {rt.health_check.interval_seconds}s[/]")
-        info.append(f"    [dim]timeout        : {rt.health_check.timeout_seconds}s[/]")
+        info.append(
+            f"    [dim]intervalle     : {rt.health_check.interval_seconds}s[/]")
+        info.append(
+            f"    [dim]timeout        : {rt.health_check.timeout_seconds}s[/]")
 
     info.append(
         f"  [cyan]Retry            :[/][yellow] {rt.retry.max_attempts} tentative(s)[/]"
     )
     if rt.retry.max_attempts > 1:
-        info.append(f"    [dim]backoff        : {rt.retry.backoff_seconds}s[/]")
+        info.append(
+            f"    [dim]backoff        : {rt.retry.backoff_seconds}s[/]")
 
     # Vérifie le disque actuel si le plugin est installé
     data_dir = plugin_dir / "data"
@@ -186,7 +190,8 @@ async def _sandbox_limits(args) -> None:
 
     content = Group(*info)
     title = f"[bold green]🛡️  Limites ressources : {escape(name)}[/]"
-    console.print(Panel(content, title=title, expand=False, border_style="cyan"))
+    console.print(Panel(content, title=title,
+                  expand=False, border_style="cyan"))
 
 
 # ── network ───────────────────────────────────────────────────
@@ -212,7 +217,8 @@ async def _sandbox_network(args) -> None:
     try:
         manifest = _load_manifest(plugin_dir)
     except Exception as e:
-        error_console.print(f"[bold red]❌ Manifeste invalide :[/] {escape(str(e))}")
+        error_console.print(
+            f"[bold red]❌ Manifeste invalide :[/] {escape(str(e))}")
         sys.exit(1)
 
     info = []
@@ -237,7 +243,8 @@ async def _sandbox_network(args) -> None:
     )
 
     # Vérifie si des imports réseau sont dans la whitelist du plugin
-    allowed_network = [i for i in manifest.allowed_imports if i in NETWORK_IMPORTS]
+    allowed_network = [
+        i for i in manifest.allowed_imports if i in NETWORK_IMPORTS]
     blocked_by_ast = [
         e for e in result.errors if any(net in e for net in NETWORK_IMPORTS)
     ]
@@ -258,12 +265,15 @@ async def _sandbox_network(args) -> None:
     else:
         info.append("✅ [green]Aucun import réseau détecté dans le code[/]")
 
-    info.append("\n[dim]Note : isolation réseau OS (namespaces) — Linux uniquement.[/]")
-    info.append("[dim]Pour une isolation complète, utilisez un conteneur Docker.[/]")
+    info.append(
+        "\n[dim]Note : isolation réseau OS (namespaces) — Linux uniquement.[/]")
+    info.append(
+        "[dim]Pour une isolation complète, utilisez un conteneur Docker.[/]")
 
     content = Group(*info)
     title = f"[bold green]🌐 Politique réseau : {escape(name)}[/]"
-    console.print(Panel(content, title=title, expand=False, border_style="cyan"))
+    console.print(Panel(content, title=title,
+                  expand=False, border_style="cyan"))
 
 
 # ── fs ────────────────────────────────────────────────────────
@@ -284,7 +294,8 @@ async def _sandbox_fs(args) -> None:
     try:
         manifest = _load_manifest(plugin_dir)
     except Exception as e:
-        error_console.print(f"[bold red]❌ Manifeste invalide :[/] {escape(str(e))}")
+        error_console.print(
+            f"[bold red]❌ Manifeste invalide :[/] {escape(str(e))}")
         sys.exit(1)
 
     fs = manifest.filesystem
@@ -320,7 +331,8 @@ async def _sandbox_fs(args) -> None:
 
     content = Group(*info)
     title = f"[bold green]📁 Politique filesystem : {escape(name)}[/]"
-    console.print(Panel(content, title=title, expand=False, border_style="cyan"))
+    console.print(Panel(content, title=title,
+                  expand=False, border_style="cyan"))
 
     # Vérifie si le dossier data/ existe, le créer si nécessaire
     data_dir = plugin_dir / "data"

--- a/xcore/cli/validate_cmd.py
+++ b/xcore/cli/validate_cmd.py
@@ -61,7 +61,8 @@ def validate_full(
 
     # 3. Signature (Trusted seulement)
     if manifest.execution_mode == ExecutionMode.TRUSTED and secret_key:
-        from xcore.kernel.security.signature import SignatureError, verify_plugin
+        from xcore.kernel.security.signature import (SignatureError,
+                                                     verify_plugin)
 
         try:
             verify_plugin(manifest, secret_key)

--- a/xcore/configurations/__init__.py
+++ b/xcore/configurations/__init__.py
@@ -1,14 +1,7 @@
 from .loader import ConfigLoader, XcoreConfig
-from .sections import (
-    AppConfig,
-    CacheConfig,
-    DatabaseConfig,
-    ObservabilityConfig,
-    PluginConfig,
-    SchedulerConfig,
-    SecurityConfig,
-    ServicesConfig,
-)
+from .sections import (AppConfig, CacheConfig, DatabaseConfig,
+                       ObservabilityConfig, PluginConfig, SchedulerConfig,
+                       SecurityConfig, ServicesConfig)
 
 __all__ = [
     "ConfigLoader",

--- a/xcore/configurations/helper.py
+++ b/xcore/configurations/helper.py
@@ -18,7 +18,8 @@ def _resolve(value: Any) -> Any:
             var = m.group(1)
             resolved = os.environ.get(var)
             if resolved is None:
-                logger.warning(f"Variable d'environnement non définie : ${{{var}}}")
+                logger.warning(
+                    f"Variable d'environnement non définie : ${{{var}}}")
                 return ""
             return resolved
 

--- a/xcore/configurations/loader.py
+++ b/xcore/configurations/loader.py
@@ -14,21 +14,10 @@ from pathlib import Path
 from typing import Any
 
 from .helper import _resolve
-from .sections import (
-    AppConfig,
-    CacheConfig,
-    DatabaseConfig,
-    LoggingConfig,
-    MarketplaceConfig,
-    MetricsConfig,
-    ObservabilityConfig,
-    PluginConfig,
-    SchedulerConfig,
-    SecurityConfig,
-    ServicesConfig,
-    TracingConfig,
-    XcoreConfig,
-)
+from .sections import (AppConfig, CacheConfig, DatabaseConfig, LoggingConfig,
+                       MarketplaceConfig, MetricsConfig, ObservabilityConfig,
+                       PluginConfig, SchedulerConfig, SecurityConfig,
+                       ServicesConfig, TracingConfig, XcoreConfig)
 
 logger = logging.getLogger("xcore.config")
 
@@ -104,7 +93,8 @@ class ConfigLoader:
             load_dotenv(dotenv_path=path, override=False)
             logger.info(f".env loaded : {path}")
         except ImportError:
-            logger.warning("python-dotenv not installed — pip install python-dotenv")
+            logger.warning(
+                "python-dotenv not installed — pip install python-dotenv")
 
     @classmethod
     def _apply_env_overrides(cls, raw: dict[str, Any]) -> dict[str, Any]:
@@ -112,7 +102,7 @@ class ConfigLoader:
         for key, value in os.environ.items():
             if not key.startswith(prefix):
                 continue
-            parts = key[len(prefix) :].lower().split("__")
+            parts = key[len(prefix):].lower().split("__")
             target = raw
             for part in parts[:-1]:
                 target = target.setdefault(part, {})
@@ -132,7 +122,8 @@ class ConfigLoader:
             app=cls._parse_app(raw.get("app", {})),
             plugins=cls._parse_plugins(raw.get("plugins", {})),
             services=cls._parse_services(raw.get("services", {})),
-            observability=cls._parse_observability(raw.get("observability", {})),
+            observability=cls._parse_observability(
+                raw.get("observability", {})),
             security=cls._parse_security(raw.get("security", {})),
             marketplace=cls._parse_marketplace(raw.get("marketplace", {})),
             raw=raw,

--- a/xcore/configurations/sections.py
+++ b/xcore/configurations/sections.py
@@ -137,7 +137,8 @@ class XcoreConfig:
     app: AppConfig = field(default_factory=AppConfig)
     plugins: PluginConfig = field(default_factory=PluginConfig)
     services: ServicesConfig = field(default_factory=ServicesConfig)
-    observability: ObservabilityConfig = field(default_factory=ObservabilityConfig)
+    observability: ObservabilityConfig = field(
+        default_factory=ObservabilityConfig)
     security: SecurityConfig = field(default_factory=SecurityConfig)
     marketplace: MarketplaceConfig = field(default_factory=MarketplaceConfig)
     raw: dict[str, Any] = field(default_factory=dict)

--- a/xcore/kernel/api/auth.py
+++ b/xcore/kernel/api/auth.py
@@ -23,7 +23,8 @@ class AuthBackend(Protocol):
 
     async def extract_token(self, request: RequestAdapter) -> str | None: ...
 
-    async def has_permission(self, payload: AuthPayload, permission: str) -> bool: ...
+    async def has_permission(self, payload: AuthPayload,
+                             permission: str) -> bool: ...
 
 
 # ── Registry singleton ────────────────────────────────────────

--- a/xcore/kernel/api/context.py
+++ b/xcore/kernel/api/context.py
@@ -9,12 +9,14 @@ variables, and the plugin configuration.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 if TYPE_CHECKING:
-    from .proto import EventBus, HookManager
-    from ..observability import Tracer, MetricsRegistry, HealthChecker
     from ...registry import PluginRegistry
+    from ..observability import HealthChecker, MetricsRegistry, Tracer
+    from .proto import EventBus, HookManager
+
+
 @dataclass
 class PluginContext:
     """

--- a/xcore/kernel/api/contract.py
+++ b/xcore/kernel/api/contract.py
@@ -8,6 +8,7 @@ ExecutionMode: Enum of execution modes.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Protocol, TypeVar, overload, runtime_checkable
 
@@ -15,7 +16,7 @@ from .proto import PluginContext
 
 # Literal dispo Python 3.8+
 try:
-    from typing import Literal
+    from typing import Awaitable, Callable, Literal
 except ImportError:
     from typing_extensions import Literal  # type: ignore[assignment]
 
@@ -31,6 +32,13 @@ if TYPE_CHECKING:
     from ...services.scheduler.service import SchedulerService
 
 T = TypeVar("T")
+
+
+@dataclass
+class Middleware:
+    name: str
+    middleware: Any
+    params: dict = field(default_factory=dict)
 
 
 class ExecutionMode(str, Enum):
@@ -117,7 +125,8 @@ class TrustedBase(ABC):
         payload: dict | None = None,
     ) -> dict:
         if self.ctx is None:
-            raise RuntimeError("call_plugin appelé avant injection du contexte.")
+            raise RuntimeError(
+                "call_plugin appelé avant injection du contexte.")
         if self.ctx.caller is None:
             raise RuntimeError(
                 f"[{self.ctx.name}] call_plugin() non disponible "
@@ -140,15 +149,14 @@ class TrustedBase(ABC):
     def get_service(self, name: "Literal['mongodb']") -> "MongoDBAdapter": ...
 
     @overload
-    def get_service(self, name:"Literal['redisAdapter']") -> "RedisAdapter": ...
-
-    @overload
-    def get_service(self, name:"Literal['syncdb']") -> "SQLAdapter": ...
-
-    @overload
     def get_service(
-        self, name: "Literal['scheduler']"
-    ) -> "SchedulerService": ...  # noqa: F811
+        self, name: "Literal['redisAdapter']") -> "RedisAdapter": ...
+
+    @overload
+    def get_service(self, name: "Literal['syncdb']") -> "SQLAdapter": ...
+
+    @overload
+    def get_service(self, name: "Literal['scheduler']") -> "SchedulerService": ...  # noqa: F811
 
     @overload
     def get_service(self, name: str) -> Any: ...  # noqa: F811
@@ -223,6 +231,18 @@ class TrustedBase(ABC):
 
     @abstractmethod
     async def handle(self, action: str, payload: dict) -> dict: ...
+
+    def add_middleware(self) -> dict:
+        """
+        Ajoute un middleware à l'exécution.
+        :return: {
+            "name": str,
+            "middleware": Middleware_class,
+            "params": dict,
+        }
+
+        """
+        return {}
 
     # ── Hooks cycle de vie (optionnels) ───────────────────────────────────────
 

--- a/xcore/kernel/api/proto.py
+++ b/xcore/kernel/api/proto.py
@@ -1,13 +1,19 @@
-from typing import Protocol, Callable, Any, Awaitable, Optional, List, Dict
 from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Protocol
+
 from xcore.kernel.events.section import HookResult
 from xcore.kernel.observability import MetricsRegistry, Tracer
+
+
 class EventBus(Protocol):
-    def on(self, event_name: str, priority: int = 50, name: str | None = None) -> Callable: ...
-    async def emit(self, event_name: str, data: dict[str, Any] | None = None) -> list[Any]: ...
+    def on(self, event_name: str, priority: int = 50,
+           name: str | None = None) -> Callable: ...
+    async def emit(self, event_name: str,
+                   data: dict[str, Any] | None = None) -> list[Any]: ...
     # Note : on ne met PAS 'clear' ici.
     def once(self, event_name: str, priority: int = 50) -> Callable: ...
-    def emit_sync(self, event_name: str, data: dict[str, Any] | None = None) -> None: ...
+    def emit_sync(self, event_name: str,
+                  data: dict[str, Any] | None = None) -> None: ...
 
 
 class HookManager(Protocol):
@@ -53,6 +59,7 @@ class HealthChecker(Protocol):
 
 class PluginRegistry(Protocol):
     ...
+
 
 @dataclass
 class PluginContext:

--- a/xcore/kernel/api/versioning.py
+++ b/xcore/kernel/api/versioning.py
@@ -52,7 +52,7 @@ def check_compatibility(framework_version_expr: str, core_version: str) -> bool:
         part = part.strip()
         for op in (">=", "<=", ">", "<", "=="):
             if part.startswith(op):
-                target = APIVersion.parse(part[len(op) :])
+                target = APIVersion.parse(part[len(op):])
                 ok = {
                     ">=": core >= target,
                     "<=": core <= target,

--- a/xcore/kernel/events/bus.py
+++ b/xcore/kernel/events/bus.py
@@ -79,7 +79,8 @@ class EventBus:
 
         # If it's a wildcard, pre-compile and store it
         if any(c in event_name for c in "*?[]") and event_name not in self._wildcard_patterns:
-            self._wildcard_patterns[event_name] = re.compile(fnmatch.translate(event_name))
+            self._wildcard_patterns[event_name] = re.compile(
+                fnmatch.translate(event_name))
 
         entry = _HandlerEntry(
             handler=handler,

--- a/xcore/kernel/observability/health.py
+++ b/xcore/kernel/observability/health.py
@@ -76,7 +76,8 @@ class HealthChecker:
 
             duration = (time.monotonic() - start) * 1000
             results.append(
-                CheckResult(name=name, status=status, message=msg, duration_ms=duration)
+                CheckResult(name=name, status=status,
+                            message=msg, duration_ms=duration)
             )
 
         overall = HealthStatus.HEALTHY

--- a/xcore/kernel/permissions/engine.py
+++ b/xcore/kernel/permissions/engine.py
@@ -51,11 +51,13 @@ class PermissionEngine:
         self._cache.clear()  # Invalidate cache on policy change
         if not raw_permissions:
             self._policies[plugin_name] = PolicySet.deny_all(plugin_name)
-            logger.debug(f"[{plugin_name}] Aucune permission déclarée → DENY ALL")
+            logger.debug(
+                f"[{plugin_name}] Aucune permission déclarée → DENY ALL")
         else:
             ps = PolicySet.from_list(plugin_name, raw_permissions)
             self._policies[plugin_name] = ps
-            logger.debug(f"[{plugin_name}] {len(ps.policies)} règle(s) chargée(s)")
+            logger.debug(
+                f"[{plugin_name}] {len(ps.policies)} règle(s) chargée(s)")
 
     def grant_all(self, plugin_name: str) -> None:
         """Grant all permissions to a plugin."""

--- a/xcore/kernel/permissions/policies.py
+++ b/xcore/kernel/permissions/policies.py
@@ -125,7 +125,8 @@ class PolicySet:
         """Permissive policy — for internal use / testing only."""
         return cls(
             plugin_name=plugin_name,
-            policies=[Policy(resource="*", actions=["*"], effect=PolicyEffect.ALLOW)],
+            policies=[Policy(resource="*", actions=["*"],
+                             effect=PolicyEffect.ALLOW)],
         )
 
     @classmethod

--- a/xcore/kernel/runtime/activator.py
+++ b/xcore/kernel/runtime/activator.py
@@ -59,7 +59,8 @@ class TrustedActivator(PluginActivator):
             entry_point=manifest.entry_point,
         )
         if not scan.passed:
-            logger.warning(f"[{manifest.name}] Scan AST (non bloquant) : {scan}")
+            logger.warning(
+                f"[{manifest.name}] Scan AST (non bloquant) : {scan}")
 
         lm = LifecycleManager(
             manifest,

--- a/xcore/kernel/runtime/dependency.py
+++ b/xcore/kernel/runtime/dependency.py
@@ -40,7 +40,8 @@ class DependencyGraph(Generic[T]):
         Means 'node' requires 'depends_on'.
         """
         if node not in self._nodes:
-            raise ValueError(f"Node '{node}' not in graph. Call add_node first.")
+            raise ValueError(
+                f"Node '{node}' not in graph. Call add_node first.")
         if depends_on not in self._nodes:
             # Note: We might want to allow external dependencies that are not in this batch,
             # but for topo_sort within a batch, both must be present.
@@ -59,10 +60,12 @@ class DependencyGraph(Generic[T]):
         """
         # Kahn's algorithm
         # Copy in-degrees (number of dependencies each node has)
-        in_degree = {name: len(deps) for name, deps in self._dependencies.items()}
+        in_degree = {name: len(deps)
+                     for name, deps in self._dependencies.items()}
 
         # Queue of nodes with no dependencies
-        queue = deque([name for name, degree in in_degree.items() if degree == 0])
+        queue = deque(
+            [name for name, degree in in_degree.items() if degree == 0])
 
         ordered_names = []
         while queue:

--- a/xcore/kernel/runtime/lifecycle.py
+++ b/xcore/kernel/runtime/lifecycle.py
@@ -35,9 +35,11 @@ class LoadError(Exception):
 
 class LifecycleManager:
     """
-        Manages the complete lifecycle of a Trusted plugin in memory.
+    Manages the complete lifecycle of a Trusted plugin in memory.
     """
-    PROTECTED_SERVICES = {"db", "cache", "scheduler", "events", "hooks", "database"}
+
+    PROTECTED_SERVICES = {"db", "cache",
+                          "scheduler", "events", "hooks", "database"}
 
     def __init__(
         self,
@@ -61,6 +63,7 @@ class LifecycleManager:
         self._loaded_at: float | None = None
         # APIRouter exposé par le plugin (optionnel)
         self.plugin_router: Any | None = None
+        self.plugin_middlewares: list[Any] = []
 
         self._sm = StateMachine(
             manifest.name,
@@ -82,7 +85,8 @@ class LifecycleManager:
         return None if self._loaded_at is None else time.monotonic() - self._loaded_at
 
     def _on_state_change(self, old: PluginState, new: PluginState) -> None:
-        logger.debug(f"[{self.manifest.name}] état : {old.value} → {new.value}")
+        logger.debug(
+            f"[{self.manifest.name}] état : {old.value} → {new.value}")
         if self._events:
             self._events.emit_sync(
                 f"plugin.{self.manifest.name}.state_changed",
@@ -114,7 +118,8 @@ class LifecycleManager:
             )
         except Exception as e:
             self._sm.transition("error")
-            raise LoadError(f"[{self.manifest.name}] Échec chargement : {e}") from e
+            raise LoadError(
+                f"[{self.manifest.name}] Échec chargement : {e}") from e
 
     async def _do_load(self) -> None:
         entry = self.manifest.plugin_dir / self.manifest.entry_point
@@ -167,6 +172,7 @@ class LifecycleManager:
 
         # Collecte le router HTTP custom si le plugin en expose un
         self._collect_router()
+        self._collect_middlewares()
 
     async def _invoke_hooks(self, hook_names: list[str]) -> None:
         """Invoque une série de hooks sur l'instance s'ils existent."""
@@ -181,7 +187,8 @@ class LifecycleManager:
                     else:
                         hook()
                 except Exception as e:
-                    logger.error(f"[{self.manifest.name}] Erreur hook {name} : {e}")
+                    logger.error(
+                        f"[{self.manifest.name}] Erreur hook {name} : {e}")
                     raise
 
     def _instantiate(self, cls) -> BasePlugin:
@@ -238,7 +245,8 @@ class LifecycleManager:
             raise
 
         return (
-            result if isinstance(result, dict) else {"status": "ok", "result": result}
+            result if isinstance(result, dict) else {
+                "status": "ok", "result": result}
         )
 
     # ── Reload ────────────────────────────────────────────────
@@ -256,7 +264,8 @@ class LifecycleManager:
             logger.info(f"[{self.manifest.name}] reloaded")
         except Exception as e:
             self._sm.transition("error")
-            raise LoadError(f"[{self.manifest.name}] failed reload : {e}") from e
+            raise LoadError(
+                f"[{self.manifest.name}] failed reload : {e}") from e
 
     # ── Unload ────────────────────────────────────────────────
 
@@ -310,6 +319,26 @@ class LifecycleManager:
         except Exception as e:
             logger.error(f"[{self.manifest.name}] get_router() erreur : {e}")
 
+    def _collect_middlewares(self) -> None:
+        add_middlewares = getattr(self._instance, "add_middlewares", None)
+        if add_middlewares is None:
+            return
+
+        if not callable(add_middlewares):
+            return
+
+        try:
+            middlewares = add_middlewares()
+            if middlewares is not None:
+                self.plugin_middlewares.append(middlewares)
+                logger.info(
+                    f"[{self.manifest.name}] 🔄 Middlewares collectés "
+                    f"({len(self.plugin_middlewares)} middleware(s))"
+                )
+        except Exception as e:
+            logger.error(
+                f"[{self.manifest.name}] get_middlewares() erreur : {e}")
+
     # ── Propagation des services (fix #3 v1) ──────────────────
 
     def propagate_services(self, *, is_reload: bool = False) -> dict:
@@ -332,10 +361,10 @@ class LifecycleManager:
         if not instance_services:
             return self._services
 
-        #if collisions := set(instance_services.keys()) & self.PROTECTED_SERVICES:
+        # if collisions := set(instance_services.keys()) & self.PROTECTED_SERVICES:
         #    raise ValueError(
         #        f"[{self.manifest.name}] Tentative d'écrasement de services protégés "
-        #Tentative         f"par le noyau : {collisions}"
+        # Tentative         f"par le noyau : {collisions}"
         #    )
 
         # Enregistrement explicite dans le registre pour le scoping/discovery
@@ -360,7 +389,8 @@ class LifecycleManager:
         else:
             # Fallback de sécurité si le registre est absent (pour les tests ou configs minimales)
             # On définit une liste minimale de services à protéger
-            protected = {"db", "cache", "scheduler", "events", "hooks", "database"}
+            protected = {"db", "cache", "scheduler",
+                         "events", "hooks", "database"}
             collisions = set(instance_services.keys()) & protected
             if collisions:
                 raise PermissionError(
@@ -387,7 +417,8 @@ class LifecycleManager:
                 f"{sorted(instance_services.keys())}"
             )
         else:
-            new_keys = set(instance_services.keys()) - set(self._services.keys())
+            new_keys = set(instance_services.keys()) - \
+                set(self._services.keys())
             for k in new_keys:
                 self._services[k] = instance_services[k]
             if new_keys:

--- a/xcore/kernel/runtime/lifecycle.py
+++ b/xcore/kernel/runtime/lifecycle.py
@@ -38,8 +38,7 @@ class LifecycleManager:
     Manages the complete lifecycle of a Trusted plugin in memory.
     """
 
-    PROTECTED_SERVICES = {"db", "cache",
-                          "scheduler", "events", "hooks", "database"}
+    PROTECTED_SERVICES = {"db", "cache", "scheduler", "events", "hooks", "database"}
 
     def __init__(
         self,
@@ -85,8 +84,7 @@ class LifecycleManager:
         return None if self._loaded_at is None else time.monotonic() - self._loaded_at
 
     def _on_state_change(self, old: PluginState, new: PluginState) -> None:
-        logger.debug(
-            f"[{self.manifest.name}] état : {old.value} → {new.value}")
+        logger.debug(f"[{self.manifest.name}] état : {old.value} → {new.value}")
         if self._events:
             self._events.emit_sync(
                 f"plugin.{self.manifest.name}.state_changed",
@@ -118,8 +116,7 @@ class LifecycleManager:
             )
         except Exception as e:
             self._sm.transition("error")
-            raise LoadError(
-                f"[{self.manifest.name}] Échec chargement : {e}") from e
+            raise LoadError(f"[{self.manifest.name}] Échec chargement : {e}") from e
 
     async def _do_load(self) -> None:
         entry = self.manifest.plugin_dir / self.manifest.entry_point
@@ -187,8 +184,7 @@ class LifecycleManager:
                     else:
                         hook()
                 except Exception as e:
-                    logger.error(
-                        f"[{self.manifest.name}] Erreur hook {name} : {e}")
+                    logger.error(f"[{self.manifest.name}] Erreur hook {name} : {e}")
                     raise
 
     def _instantiate(self, cls) -> BasePlugin:
@@ -245,8 +241,7 @@ class LifecycleManager:
             raise
 
         return (
-            result if isinstance(result, dict) else {
-                "status": "ok", "result": result}
+            result if isinstance(result, dict) else {"status": "ok", "result": result}
         )
 
     # ── Reload ────────────────────────────────────────────────
@@ -264,8 +259,7 @@ class LifecycleManager:
             logger.info(f"[{self.manifest.name}] reloaded")
         except Exception as e:
             self._sm.transition("error")
-            raise LoadError(
-                f"[{self.manifest.name}] failed reload : {e}") from e
+            raise LoadError(f"[{self.manifest.name}] failed reload : {e}") from e
 
     # ── Unload ────────────────────────────────────────────────
 
@@ -320,7 +314,7 @@ class LifecycleManager:
             logger.error(f"[{self.manifest.name}] get_router() erreur : {e}")
 
     def _collect_middlewares(self) -> None:
-        add_middlewares = getattr(self._instance, "add_middlewares", None)
+        add_middlewares = getattr(self._instance, "add_middleware", None)
         if add_middlewares is None:
             return
 
@@ -336,8 +330,7 @@ class LifecycleManager:
                     f"({len(self.plugin_middlewares)} middleware(s))"
                 )
         except Exception as e:
-            logger.error(
-                f"[{self.manifest.name}] get_middlewares() erreur : {e}")
+            logger.error(f"[{self.manifest.name}] get_middlewares() erreur : {e}")
 
     # ── Propagation des services (fix #3 v1) ──────────────────
 
@@ -389,8 +382,7 @@ class LifecycleManager:
         else:
             # Fallback de sécurité si le registre est absent (pour les tests ou configs minimales)
             # On définit une liste minimale de services à protéger
-            protected = {"db", "cache", "scheduler",
-                         "events", "hooks", "database"}
+            protected = {"db", "cache", "scheduler", "events", "hooks", "database"}
             collisions = set(instance_services.keys()) & protected
             if collisions:
                 raise PermissionError(
@@ -417,8 +409,7 @@ class LifecycleManager:
                 f"{sorted(instance_services.keys())}"
             )
         else:
-            new_keys = set(instance_services.keys()) - \
-                set(self._services.keys())
+            new_keys = set(instance_services.keys()) - set(self._services.keys())
             for k in new_keys:
                 self._services[k] = instance_services[k]
             if new_keys:

--- a/xcore/kernel/runtime/loader.py
+++ b/xcore/kernel/runtime/loader.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from ..context import KernelContext
 
 from ...kernel.security.validation import ManifestValidator
-
 # from ...sdk.plugin_base import PluginDependency
 from ..api.contract import PluginHandler
 from .activator import ActivatorRegistry, SandboxedActivator, TrustedActivator
@@ -70,7 +69,8 @@ class PluginLoader:
         # Activator registry (Strategy Pattern)
         self._activators = ActivatorRegistry()
         self._activators.register(ExecutionMode.TRUSTED, TrustedActivator())
-        self._activators.register(ExecutionMode.SANDBOXED, SandboxedActivator())
+        self._activators.register(
+            ExecutionMode.SANDBOXED, SandboxedActivator())
         self._activators.register(ExecutionMode.LEGACY, TrustedActivator())
 
         self._validator = ManifestValidator()
@@ -212,14 +212,16 @@ class PluginLoader:
     async def load(self, plugin_name: str) -> None:
         plugin_dir = Path(self._config.directory) / plugin_name
         if not plugin_dir.is_dir():
-            raise FileNotFoundError(f"Dossier plugin introuvable : {plugin_dir}")
+            raise FileNotFoundError(
+                f"Dossier plugin introuvable : {plugin_dir}")
 
         manifest = self._validator.load_and_validate(plugin_dir)
 
         for dep in manifest.requires:
             dep_name = dep.name if hasattr(dep, "name") else str(dep)
             if dep_name not in self._handlers:
-                logger.info(f"[{plugin_name}] Dépendance '{dep_name}' → chargement...")
+                logger.info(
+                    f"[{plugin_name}] Dépendance '{dep_name}' → chargement...")
                 await self.load(dep_name)
 
         await self._activate(manifest)
@@ -254,7 +256,8 @@ class PluginLoader:
         if name in self._handlers:
             return self._handlers[name]
         available = sorted(list(self._handlers.keys()))
-        raise KeyError(f"Plugin '{name}' non trouvé. Disponibles : {available}")
+        raise KeyError(
+            f"Plugin '{name}' non trouvé. Disponibles : {available}")
 
     def has(self, name: str) -> bool:
         return name in self._handlers
@@ -289,7 +292,8 @@ class PluginLoader:
                 # dep est un PluginDependency object
                 dep_name = dep.name if hasattr(dep, "name") else str(dep)
                 if dep_name not in graph:
-                    raise ValueError(f"[{m.name}] Missing dependency '{dep_name}'")
+                    raise ValueError(
+                        f"[{m.name}] Missing dependency '{dep_name}'")
                 graph.add_dependency(m.name, dep_name)
 
         return graph.get_ordered()
@@ -321,3 +325,20 @@ class PluginLoader:
             if hasattr(handler, "plugin_router") and handler.plugin_router is not None:
                 routers.append((name, handler.plugin_router))
         return routers
+
+    def collect_middlewares(self) -> list[Any]:
+        """
+        Collecte tous les middlewares exposés par les plugins chargés.
+
+        Retourne une liste de middlewares pour chaque plugin ayant implémenté add_middlewares().
+
+        Utilisé par Xcore._attach_middlewares() pour monter les middlewares sur l'app FastAPI.
+        """
+        middlewares = []
+        for name, handler in self._handlers.items():
+            if (
+                hasattr(handler, "plugin_middlewares")
+                and handler.plugin_middlewares is not None
+            ):
+                middlewares.append(handler.plugin_middlewares)
+        return middlewares

--- a/xcore/kernel/runtime/middlewares/__init__.py
+++ b/xcore/kernel/runtime/middlewares/__init__.py
@@ -5,13 +5,12 @@ from .ratelimit import RateLimitMiddleware
 from .retry import RetryMiddleware
 from .tracing import TracingMiddleware
 
-
 __all__ = [
     "Middleware",
-" MiddlewarePipeline",
-" MiddlewareRegistry",
-" PermissionMiddleware",
-" RateLimitMiddleware",
-" RetryMiddleware",
-" TracingMiddleware",
+    " MiddlewarePipeline",
+    " MiddlewareRegistry",
+    " PermissionMiddleware",
+    " RateLimitMiddleware",
+    " RetryMiddleware",
+    " TracingMiddleware",
 ]

--- a/xcore/kernel/runtime/middlewares/middleware_registry.py
+++ b/xcore/kernel/runtime/middlewares/middleware_registry.py
@@ -21,7 +21,8 @@ class MiddlewareRegistry:
 
     def __init__(self) -> None:
         # factory: (context_dict) -> Middleware
-        self._factories: dict[str, Callable[[dict[str, Any]], "Middleware"]] = {}
+        self._factories: dict[str, Callable[[
+            dict[str, Any]], "Middleware"]] = {}
 
     def register(self, name: str, factory: Callable[[dict[str, Any]], "Middleware"]) -> None:
         """Registers a middleware factory."""

--- a/xcore/kernel/runtime/middlewares/permissions.py
+++ b/xcore/kernel/runtime/middlewares/permissions.py
@@ -5,8 +5,9 @@ permissions.py — Middleware for plugin permission checks.
 from __future__ import annotations
 
 import logging
-from .middleware import Middleware
+
 from ...permissions.engine import PermissionDenied
+from .middleware import Middleware
 
 logger = logging.getLogger("xcore.runtime.middlewares.permissions")
 

--- a/xcore/kernel/runtime/middlewares/ratelimit.py
+++ b/xcore/kernel/runtime/middlewares/ratelimit.py
@@ -4,8 +4,8 @@ ratelimit.py — Middleware for plugin rate limiting.
 
 from __future__ import annotations
 
-from .middleware import Middleware
 from ...sandbox.limits import RateLimitExceeded
+from .middleware import Middleware
 
 
 class RateLimitMiddleware(Middleware):

--- a/xcore/kernel/runtime/middlewares/retry.py
+++ b/xcore/kernel/runtime/middlewares/retry.py
@@ -33,8 +33,10 @@ class RetryMiddleware(Middleware):
 
         # Extraction sécurisée des paramètres de retry
         retry_params = getattr(retry_cfg, "retry", None) if retry_cfg else None
-        max_attempts = getattr(retry_params, "max_attempts", 1) if retry_params else 1
-        backoff = getattr(retry_params, "backoff_seconds", 0.0) if retry_params else 0.0
+        max_attempts = getattr(
+            retry_params, "max_attempts", 1) if retry_params else 1
+        backoff = getattr(retry_params, "backoff_seconds",
+                          0.0) if retry_params else 0.0
 
         last_err = None
         for attempt in range(1, max_attempts + 1):

--- a/xcore/kernel/runtime/supervisor.py
+++ b/xcore/kernel/runtime/supervisor.py
@@ -5,7 +5,6 @@ Agrège : PluginLoader + PermissionEngine + rate limiter + retry + routing appel
 C'est lui qu'expose Xcore via xcore.plugins.
 """
 
-
 from __future__ import annotations
 
 import contextlib
@@ -18,21 +17,11 @@ if TYPE_CHECKING:
 from ..permissions.engine import PermissionEngine
 from ..sandbox.limits import RateLimiterRegistry
 from .loader import PluginLoader
-from .middlewares import (
-    Middleware,
-    MiddlewarePipeline,
-    MiddlewareRegistry,
-    PermissionMiddleware,
-    RateLimitMiddleware,
-    RetryMiddleware,
-    TracingMiddleware
-)
+from .middlewares import (Middleware, MiddlewarePipeline, MiddlewareRegistry,
+                          PermissionMiddleware, RateLimitMiddleware,
+                          RetryMiddleware, TracingMiddleware)
 
 logger = logging.getLogger("xcore.runtime.supervisor")
-
-
-
-
 
 
 class PluginSupervisor:
@@ -73,25 +62,32 @@ class PluginSupervisor:
     def _setup_default_middlewares(self) -> None:
         """Registers default middleware factories."""
         self._middleware_registry.register(
-            "tracing", lambda ctx: TracingMiddleware(ctx.get("tracer"), ctx.get("metrics"))
+            "tracing",
+            lambda ctx: TracingMiddleware(
+                ctx.get("tracer"), ctx.get("metrics")),
         )
         self._middleware_registry.register(
             "rate_limit", lambda ctx: RateLimitMiddleware(ctx.get("rate"))
         )
         self._middleware_registry.register(
-            "permissions", lambda ctx: PermissionMiddleware(ctx.get("permissions"))
+            "permissions", lambda ctx: PermissionMiddleware(
+                ctx.get("permissions"))
         )
-        self._middleware_registry.register("retry", lambda _: RetryMiddleware())
+        self._middleware_registry.register(
+            "retry", lambda _: RetryMiddleware())
 
     async def boot(self) -> None:
         """Instancie le loader et charge tous les plugins."""
         # Souscription réactive aux événements de plugin
         if self._events:
-            self._events.subscribe("plugin.*.services_registered", self._on_plugin_services_registered)
+            self._events.subscribe(
+                "plugin.*.services_registered", self._on_plugin_services_registered
+            )
 
         self._loader = PluginLoader(
             ctx=self._ctx,
-            caller=lambda name, action, payload: self.call(name, action, payload),
+            caller=lambda name, action, payload: self.call(
+                name, action, payload),
         )
         report = await self._loader.load_all()
         logger.info(
@@ -105,7 +101,9 @@ class PluginSupervisor:
                 try:
                     self._registry.register_core_service(name, svc)
                 except Exception as e:
-                    logger.warning(f"Erreur lors de l'enregistrement du service noyau '{name}': {e}")
+                    logger.warning(
+                        f"Erreur lors de l'enregistrement du service noyau '{name}': {e}"
+                    )
 
         # Note: L'enregistrement des permissions, rate limits et registry
         # est maintenant géré de manière réactive via _on_plugin_services_registered
@@ -146,7 +144,8 @@ class PluginSupervisor:
                         f"[{name}] Rate limit : {rl.calls}/{rl.period_seconds}s"
                     )
             except Exception as e:
-                logger.error(f"[{name}] Erreur enregistrement rate limit : {e}")
+                logger.error(
+                    f"[{name}] Erreur enregistrement rate limit : {e}")
 
     async def _on_plugin_services_registered(self, event) -> None:
         """Handler réactif appelé quand un plugin a enregistré ses services."""
@@ -165,7 +164,8 @@ class PluginSupervisor:
         # 3. Enregistrement dans le registry si disponible
         if self._registry and self._loader:
             with contextlib.suppress(KeyError):
-                self._registry.register(plugin_name, self._loader.get(plugin_name))
+                self._registry.register(
+                    plugin_name, self._loader.get(plugin_name))
 
     def _load_permissions(self, plugin_names: list[str]) -> None:
         """Charge les policies de chaque plugin dans le PermissionEngine."""
@@ -218,9 +218,13 @@ class PluginSupervisor:
         (exécuté avant les autres).
         """
         if self._pipeline is None:
-            raise RuntimeError("Le pipeline n'est pas encore initialisé. Appelez boot() d'abord.")
+            raise RuntimeError(
+                "Le pipeline n'est pas encore initialisé. Appelez boot() d'abord."
+            )
         self._pipeline.add_middleware(middleware, first=first)
-        logger.info(f"Middleware {middleware.__class__.__name__} enregistré dynamiquement.")
+        logger.info(
+            f"Middleware {middleware.__class__.__name__} enregistré dynamiquement."
+        )
 
     def get_active_middlewares(self) -> list[Middleware]:
         """Retourne la liste des middlewares actifs dans la pipeline."""
@@ -259,6 +263,9 @@ class PluginSupervisor:
 
     def collect_plugin_routers(self) -> list[tuple[str, Any]]:
         return self._loader.collect_plugin_routers() if self._loader else []
+
+    def collect_middlewares(self) -> list[Any]:
+        return self._loader.collect_middlewares() if self._loader else []
 
     def permissions_status(self) -> dict:
         """Expose l'état du moteur de permissions (audit log + policies)."""

--- a/xcore/kernel/sandbox/__init__.py
+++ b/xcore/kernel/sandbox/__init__.py
@@ -1,4 +1,5 @@
-from .ipc import IPCChannel, IPCError, IPCProcessDead, IPCResponse, IPCTimeoutError
+from .ipc import (IPCChannel, IPCError, IPCProcessDead, IPCResponse,
+                  IPCTimeoutError)
 from .isolation import DiskQuotaExceeded, DiskWatcher, MemoryLimiter
 from .limits import RateLimiter, RateLimiterRegistry, RateLimitExceeded
 from .process_manager import SandboxConfig, SandboxProcessManager

--- a/xcore/kernel/sandbox/ipc.py
+++ b/xcore/kernel/sandbox/ipc.py
@@ -66,7 +66,8 @@ class IPCChannel:
                 self._process.stdout.readline(), timeout=self._timeout
             )
         except asyncio.TimeoutError:
-            raise IPCTimeoutError(f"Pas de réponse dans {self._timeout}s") from None
+            raise IPCTimeoutError(
+                f"Pas de réponse dans {self._timeout}s") from None
         except Exception as exc:
             raise IPCError(f"Lecture stdout : {exc}") from exc
 
@@ -79,7 +80,8 @@ class IPCChannel:
         try:
             data = json.loads(raw_str)
         except json.JSONDecodeError as exc:
-            raise IPCError(f"JSON invalide : {exc} — reçu : {raw_str!r}") from exc
+            raise IPCError(
+                f"JSON invalide : {exc} — reçu : {raw_str!r}") from exc
 
         return IPCResponse(success=data.get("status") == "ok", data=data, raw=raw_str)
 

--- a/xcore/kernel/sandbox/isolation.py
+++ b/xcore/kernel/sandbox/isolation.py
@@ -45,7 +45,8 @@ class DiskWatcher:
             "used_mb": self.current_size_mb(),
             "max_mb": self._max_disk_mb,
             "used_pct": (
-                round(used / self._max_bytes * 100, 1) if self._max_bytes else 0
+                round(used / self._max_bytes * 100,
+                      1) if self._max_bytes else 0
             ),
             "ok": used <= self._max_bytes if self._max_bytes else True,
         }

--- a/xcore/kernel/sandbox/process_manager.py
+++ b/xcore/kernel/sandbox/process_manager.py
@@ -137,7 +137,8 @@ class SandboxProcessManager:
                 raise RuntimeError(f"Ping échoué : {resp.data}")
         except asyncio.TimeoutError as e:
             await self._kill()
-            raise RuntimeError(f"Pas de réponse au ping dans {timeout}s") from e
+            raise RuntimeError(
+                f"Pas de réponse au ping dans {timeout}s") from e
 
     async def call(self, action: str, payload: dict) -> dict:
         if not self.is_available:
@@ -160,7 +161,8 @@ class SandboxProcessManager:
         code = await self._process.wait()
         if self._state == ProcessState.STOPPED:
             return
-        logger.warning(f"[{self.manifest.name}] Subprocess terminé (code={code})")
+        logger.warning(
+            f"[{self.manifest.name}] Subprocess terminé (code={code})")
         if self._process.stderr:
             with contextlib.suppress(Exception):
                 err = await asyncio.wait_for(
@@ -204,7 +206,8 @@ class SandboxProcessManager:
 
         while self._restarts < self.config.max_restarts:
             self._restarts += 1
-            delay = min(self.config.restart_delay * (2 ** (self._restarts - 1)), 60.0)
+            delay = min(self.config.restart_delay *
+                        (2 ** (self._restarts - 1)), 60.0)
             logger.info(
                 f"[{self.manifest.name}] Restart {self._restarts}/{self.config.max_restarts} dans {delay:.1f}s"
             )

--- a/xcore/kernel/sandbox/worker.py
+++ b/xcore/kernel/sandbox/worker.py
@@ -90,9 +90,11 @@ class FilesystemGuard:
                     if resolved.is_relative_to(self._plugin_dir):
                         results.append(resolved)
                     else:
-                        logger.warning(f"[sandbox:SECURITY] Tentative de traversal via manifest : {p!r}")
+                        logger.warning(
+                            f"[sandbox:SECURITY] Tentative de traversal via manifest : {p!r}")
                 except Exception as e:
-                    logger.warning(f"[sandbox:SECURITY] Erreur résolution manifest path {p!r} : {e}")
+                    logger.warning(
+                        f"[sandbox:SECURITY] Erreur résolution manifest path {p!r} : {e}")
             return results
 
         self._allowed = _resolve_safe(allowed_paths, ["data/"])
@@ -181,7 +183,8 @@ class FilesystemGuard:
                 )
             finally:
                 guard._in_guard = was
-            raise PermissionError(f"[sandbox] {label} interdit dans le sandbox")
+            raise PermissionError(
+                f"[sandbox] {label} interdit dans le sandbox")
 
         # ── Couche 1 : Filesystem ─────────────────────────────────────────────
 
@@ -261,7 +264,8 @@ class FilesystemGuard:
             "is_dir",
         ]:
             if hasattr(_Path, op):
-                setattr(_Path, op, _guarded_op(getattr(_Path, op), f"Path.{op}"))
+                setattr(_Path, op, _guarded_op(
+                    getattr(_Path, op), f"Path.{op}"))
 
         # ── Couche 2 : Exécution dynamique ────────────────────────────────────
 
@@ -359,7 +363,8 @@ class FilesystemGuard:
                 return _real_spec_from_file(name, location, *args, **kwargs)
             # Un plugin sandbox ne doit pas charger de .py arbitraire depuis le
             # système de fichiers hors de son propre namespace déjà établi.
-            _block(f"importlib.util.spec_from_file_location('{name}', '{location}')")
+            _block(
+                f"importlib.util.spec_from_file_location('{name}', '{location}')")
 
         def _guarded_find_spec(name, *args, **kwargs):
             if guard._in_guard:
@@ -405,7 +410,8 @@ class FilesystemGuard:
             with contextlib.suppress(AttributeError):
                 _ctypes.pythonapi = _blocked_ctypes_api("pythonapi")
             with contextlib.suppress(AttributeError):
-                _ctypes.cdll.LoadLibrary = _blocked_ctypes_api("cdll.LoadLibrary")
+                _ctypes.cdll.LoadLibrary = _blocked_ctypes_api(
+                    "cdll.LoadLibrary")
         logger.debug(
             f"[sandbox] Guard installé (4 couches) — "
             f"allowed={[str(p) for p in self._allowed]}, "
@@ -462,7 +468,7 @@ class _PluginImportHook:
             return None
         # Traduit xcore_plugin_<uid>.foo.bar → src_dir/foo/bar.py (ou package)
         # retire le préfixe + "."
-        relative = fullname[len(self._pkg_prefix) + 1 :]
+        relative = fullname[len(self._pkg_prefix) + 1:]
         return self._spec_for(fullname, relative)
 
     # ── Résolution ────────────────────────────────────────────────────────────
@@ -517,7 +523,7 @@ class _PluginImportHook:
         if fullname in sys.modules:
             return sys.modules[fullname]
         relative = (
-            fullname[len(self._pkg_prefix) + 1 :]
+            fullname[len(self._pkg_prefix) + 1:]
             if fullname != self._pkg_prefix
             else ""
         )
@@ -548,7 +554,8 @@ class _PluginImportHook:
             root.__path__ = [str(self._src_dir)]
             root.__package__ = self._pkg_prefix
             sys.modules[self._pkg_prefix] = root
-        logger.debug(f"[{self._uid}] Import hook installé (src={self._src_dir})")
+        logger.debug(
+            f"[{self._uid}] Import hook installé (src={self._src_dir})")
 
     def uninstall(self) -> None:
         """Retire ce hook et nettoie tous les modules du namespace."""
@@ -681,7 +688,8 @@ def _load_manifest(plugin_dir: Path) -> _PluginManifest:
         except Exception as e:
             logger.warning(f"Impossible de lire le manifeste ({fname}) : {e}")
 
-    logger.warning(f"Aucun manifeste trouvé dans {plugin_dir} — valeurs par défaut")
+    logger.warning(
+        f"Aucun manifeste trouvé dans {plugin_dir} — valeurs par défaut")
     return manifest
 
 
@@ -734,7 +742,8 @@ async def _run(plugin_dir: Path) -> None:
     manifest = _load_manifest(plugin_dir)
 
     # 2. Installation du guard filesystem (AVANT tout chargement de code plugin)
-    guard = FilesystemGuard(plugin_dir, manifest.allowed_paths, manifest.denied_paths)
+    guard = FilesystemGuard(
+        plugin_dir, manifest.allowed_paths, manifest.denied_paths)
     guard.install()
 
     # 3. Chargement du plugin dans son namespace isolé
@@ -810,7 +819,8 @@ async def _run(plugin_dir: Path) -> None:
             }
         except Exception as e:
             logger.exception(f"Erreur handle({action})")
-            response = {"status": "error", "msg": str(e), "code": "handler_error"}
+            response = {"status": "error", "msg": str(
+                e), "code": "handler_error"}
 
         _send(transport, response)
 
@@ -833,7 +843,8 @@ async def _run(plugin_dir: Path) -> None:
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print(json.dumps({"status": "error", "msg": "Usage : worker.py <plugin_dir>"}))
+        print(json.dumps(
+            {"status": "error", "msg": "Usage : worker.py <plugin_dir>"}))
         sys.exit(1)
 
     _apply_memory_limit()

--- a/xcore/kernel/security/section.py
+++ b/xcore/kernel/security/section.py
@@ -136,7 +136,8 @@ class _SimpleManifest:
         self.env = env
         # Convertit les dépendances en PluginDependency si ce sont des strings
         self.requires = [
-            dep if isinstance(dep, PluginDependency) else PluginDependency.from_raw(dep)
+            dep if isinstance(
+                dep, PluginDependency) else PluginDependency.from_raw(dep)
             for dep in requires
         ]
         self.plugin_dir = plugin_dir
@@ -149,7 +150,8 @@ class _SimpleManifest:
         self.resources = SimpleNamespace(
             timeout_seconds=10, max_memory_mb=128, max_disk_mb=50, rate_limit=rl
         )
-        hc = SimpleNamespace(enabled=True, interval_seconds=30, timeout_seconds=3)
+        hc = SimpleNamespace(
+            enabled=True, interval_seconds=30, timeout_seconds=3)
         retry = SimpleNamespace(max_attempts=1, backoff_seconds=0.0)
         self.runtime = SimpleNamespace(health_check=hc, retry=retry)
         fs = SimpleNamespace(allowed_paths=["data/"], denied_paths=["src/"])

--- a/xcore/kernel/security/signature.py
+++ b/xcore/kernel/security/signature.py
@@ -64,11 +64,13 @@ def _compute_hmac(manifest, secret_key: bytes) -> str:
     src_dir = (root / entry_path.parent).resolve()
 
     if not src_dir.exists():
-        raise SignatureError(f"Répertoire source {src_dir} introuvable dans {root}")
+        raise SignatureError(
+            f"Répertoire source {src_dir} introuvable dans {root}")
 
     # Ensure src_dir is within root or is the root itself
     if not src_dir.is_relative_to(root):
-        raise SignatureError(f"Répertoire source {src_dir} hors du dossier plugin.")
+        raise SignatureError(
+            f"Répertoire source {src_dir} hors du dossier plugin.")
 
     files = sorted(
         p for p in src_dir.rglob("*") if p.is_file() and not _should_ignore(p, root)
@@ -113,12 +115,14 @@ def verify_plugin(manifest, secret_key: bytes) -> None:
     sig_path = manifest.plugin_dir / SIG_FILENAME
 
     if not sig_path.exists():
-        raise SignatureError(f"[{manifest.name}] Signature manquante ({SIG_FILENAME}).")
+        raise SignatureError(
+            f"[{manifest.name}] Signature manquante ({SIG_FILENAME}).")
 
     try:
         sig_data = json.loads(sig_path.read_text())
     except Exception as e:
-        raise SignatureError(f"[{manifest.name}] Fichier .sig illisible : {e}") from e
+        raise SignatureError(
+            f"[{manifest.name}] Fichier .sig illisible : {e}") from e
 
     stored = sig_data.get("digest")
     if not stored:

--- a/xcore/kernel/security/validation.py
+++ b/xcore/kernel/security/validation.py
@@ -23,19 +23,14 @@ from pathlib import Path
 
 from xcore.sdk.plugin_base import PluginDependency
 
-from .section import (
-    DEFAULT_ALLOWED,
-    DEFAULT_FORBIDDEN,
-    FORBIDDEN_ATTRIBUTES,
-    FORBIDDEN_BUILTINS,
-    ScanResult,
-    _SimpleManifest,
-)
+from .section import (DEFAULT_ALLOWED, DEFAULT_FORBIDDEN, FORBIDDEN_ATTRIBUTES,
+                      FORBIDDEN_BUILTINS, ScanResult, _SimpleManifest)
 
 # ── Chargement de l'extension C++ (optionnel) ────────────────
 
 try:
-    from .scanner_core import ImportClassifier as _CppClassifier  # type: ignore
+    from .scanner_core import \
+        ImportClassifier as _CppClassifier  # type: ignore
 
     print("AST-> Cpp Classifier")
     _CPP_AVAILABLE = True
@@ -100,7 +95,8 @@ class ManifestValidator:
 
         for field_name in ("name", "version"):
             if not raw.get(field_name):
-                raise ManifestError(f"Champ obligatoire manquant : '{field_name}'")
+                raise ManifestError(
+                    f"Champ obligatoire manquant : '{field_name}'")
 
         check_compatibility(
             raw.get("framework_version", f"=={__version__}"), __version__
@@ -116,7 +112,8 @@ class ManifestValidator:
             ) from e
 
         self._inject_dotenv(raw.get("envconfiguration"), plugin_dir)
-        resolved_env = {k: _resolve_env(v) for k, v in raw.get("env", {}).items()}
+        resolved_env = {k: _resolve_env(v)
+                        for k, v in raw.get("env", {}).items()}
 
         requires_raw = raw.get("requires", []) or []
         if not isinstance(requires_raw, list):
@@ -160,7 +157,8 @@ class ManifestValidator:
         env_file = cfg.get("env_file", ".env")
         env_path = (plugin_dir / env_file).resolve()
         if not env_path.is_relative_to(plugin_dir.resolve()):
-            raise ManifestError(f"Tentative de traversal via env_file : {env_file!r}")
+            raise ManifestError(
+                f"Tentative de traversal via env_file : {env_file!r}")
         if not env_path.exists():
             raise ManifestError(
                 f"envconfiguration.inject=true mais '{env_path}' introuvable."
@@ -213,7 +211,8 @@ def _parse_allowed_imports(raw_list: list[str]) -> tuple[set[str], list[str]]:
             prefix = entry[:-2]
             if _looks_like_module(prefix):
                 prefixes.append(prefix)
-                exact.add(prefix)  # "sqlalchemy" couvre aussi "import sqlalchemy"
+                # "sqlalchemy" couvre aussi "import sqlalchemy"
+                exact.add(prefix)
             else:
                 skipped.append(entry)
         elif _looks_like_module(entry):
@@ -249,7 +248,8 @@ class ASTScanner:
         allowed_raw = DEFAULT_ALLOWED | (extra_allowed or set())
 
         # Sépare exact vs wildcards une seule fois à la construction
-        self._allowed_exact: set[str] = {p for p in allowed_raw if not p.endswith(".*")}
+        self._allowed_exact: set[str] = {
+            p for p in allowed_raw if not p.endswith(".*")}
         self._allowed_prefixes: list[str] = [
             p[:-2] for p in allowed_raw if p.endswith(".*")
         ]
@@ -290,7 +290,8 @@ class ASTScanner:
         entry_path = (plugin_dir / entry_point).resolve()
 
         if not entry_path.is_relative_to(plugin_dir):
-            result.add_error(f"Entry point hors du dossier plugin : {entry_point!r}")
+            result.add_error(
+                f"Entry point hors du dossier plugin : {entry_point!r}")
             return result
         if not entry_path.exists():
             result.add_error(f"Entry point introuvable : {entry_point!r}")
@@ -319,7 +320,8 @@ class ASTScanner:
                 extra_allowed=extra_exact | {f"{p}.*" for p in m_prefixes},
             )
         else:
-            scanner = self if not extra_exact else ASTScanner(extra_allowed=extra_exact)
+            scanner = self if not extra_exact else ASTScanner(
+                extra_allowed=extra_exact)
 
         py_files = sorted(set(src_dir.rglob("*.py")) | {entry_path})
         if not py_files:
@@ -328,7 +330,8 @@ class ASTScanner:
 
         # ── Scan des imports (C++ ou Python) ─────────────────
         if scanner._cpp is not None:
-            cpp_results = scanner._cpp.scan_directory(str(src_dir), local_modules)
+            cpp_results = scanner._cpp.scan_directory(
+                str(src_dir), local_modules)
             for fr in cpp_results:
                 for e in fr.errors:
                     result.add_error(e)
@@ -366,7 +369,8 @@ class ASTScanner:
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
                 for alias in node.names:
-                    self._check_py(alias.name, node.lineno, path, result, local_modules)
+                    self._check_py(alias.name, node.lineno,
+                                   path, result, local_modules)
 
             elif isinstance(node, ast.ImportFrom):
                 # Seul node.module est le module source.
@@ -448,7 +452,8 @@ def _check_builtins_and_attrs(
                     f"{path}:{node.lineno}: built-in interdit : {node.id!r}"
                 )
             elif node.id in forbidden:
-                result.add_error(f"{path}:{node.lineno}: nom interdit : {node.id!r}")
+                result.add_error(
+                    f"{path}:{node.lineno}: nom interdit : {node.id!r}")
 
         elif isinstance(node, ast.Attribute):
             if node.attr in FORBIDDEN_ATTRIBUTES:

--- a/xcore/registry/__init__.py
+++ b/xcore/registry/__init__.py
@@ -2,4 +2,5 @@ from .index import PluginRegistry
 from .resolver import DependencyResolver
 from .versioning import VersionConstraint, satisfies
 
-__all__ = ["PluginRegistry", "DependencyResolver", "VersionConstraint", "satisfies"]
+__all__ = ["PluginRegistry", "DependencyResolver",
+           "VersionConstraint", "satisfies"]

--- a/xcore/registry/index.py
+++ b/xcore/registry/index.py
@@ -97,7 +97,8 @@ class PluginRegistry:
 
     def register_core_service(self, name: str, obj: Any, metadata: dict | None = None) -> None:
         """Enregistre un service noyau (protégé par défaut)."""
-        self.register_service("kernel", name, obj, metadata=metadata, scope="protected")
+        self.register_service("kernel", name, obj,
+                              metadata=metadata, scope="protected")
 
     def get_service(self, service_name: str, requester: str | None = None) -> Any:
         """

--- a/xcore/registry/resolver.py
+++ b/xcore/registry/resolver.py
@@ -63,7 +63,8 @@ class DependencyResolver:
                 reverse[dep].append(name)
                 in_degree[name] += 1
 
-        queue: deque[str] = deque(sorted(n for n, d in in_degree.items() if d == 0))
+        queue: deque[str] = deque(
+            sorted(n for n, d in in_degree.items() if d == 0))
         result: list[str] = []
 
         while queue:

--- a/xcore/sdk/__init__.py
+++ b/xcore/sdk/__init__.py
@@ -6,20 +6,14 @@ Import recommandé dans un plugin :
     from xcore.sdk import PluginManifest
 """
 
-from ..kernel.api.contract import BasePlugin, ExecutionMode, TrustedBase, error, ok
+from ..kernel.api.contract import (BasePlugin, ExecutionMode, TrustedBase,
+                                   error, ok)
 from ..kernel.api.rbac import RBACChecker, require_permission, require_role
 from .adapter.asyncsql import BaseAsyncRepository
 from .adapter.syncsql import BaseSyncRepository
-from .decorators import (
-    AutoDispatchMixin,
-    RoutedPlugin,
-    action,
-    require_service,
-    route,
-    sandboxed,
-    trusted,
-    validate_payload,
-)
+from .decorators import (AutoDispatchMixin, RoutedPlugin, action,
+                         require_service, route, sandboxed, trusted,
+                         validate_payload)
 from .plugin_base import PluginManifest, ResourceConfig, RuntimeConfig
 from .routers import RouterRegistry
 

--- a/xcore/sdk/decorators.py
+++ b/xcore/sdk/decorators.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import functools
 import inspect
 import logging
-from typing import Callable, Type, Literal
+from typing import Callable, Literal, Type
 
 from pydantic import BaseModel, ValidationError
 
@@ -236,7 +236,8 @@ class RoutedPlugin:
                     )
 
                 sig = inspect.signature(fn)
-                params = [p for name, p in sig.parameters.items() if name != "self"]
+                params = [p for name, p in sig.parameters.items()
+                          if name != "self"]
                 handler.__signature__ = sig.replace(parameters=params)
                 return handler
 

--- a/xcore/sdk/plugin_base.py
+++ b/xcore/sdk/plugin_base.py
@@ -138,7 +138,7 @@ class VersionConstraint:
         for part in parts:
             for op in (">=", "<=", ">", "<", "==", "!=", "^", "~"):
                 if part.startswith(op):
-                    version_str = part[len(op) :].strip()
+                    version_str = part[len(op):].strip()
                     version = self._to_tuple(version_str)
                     specs.append((op, version))
                     break

--- a/xcore/services/cache/backends/memory.py
+++ b/xcore/services/cache/backends/memory.py
@@ -51,7 +51,8 @@ class MemoryBackend:
 
     async def set(self, key: str, value: Any, ttl: int | None = None) -> None:
         effective_ttl = ttl if ttl is not None else self._ttl
-        expires_at = (time.monotonic() + effective_ttl) if effective_ttl > 0 else None
+        expires_at = (time.monotonic() +
+                      effective_ttl) if effective_ttl > 0 else None
 
         if key in self._store:
             self._store.move_to_end(key)
@@ -94,7 +95,8 @@ class MemoryBackend:
     async def mset(self, mapping: dict[str, Any], ttl: int | None = None) -> None:
         """Définit plusieurs clés d'un coup."""
         effective_ttl = ttl if ttl is not None else self._ttl
-        expires_at = (time.monotonic() + effective_ttl) if effective_ttl > 0 else None
+        expires_at = (time.monotonic() +
+                      effective_ttl) if effective_ttl > 0 else None
 
         for k, v in mapping.items():
             if k in self._store:

--- a/xcore/services/cache/backends/redis.py
+++ b/xcore/services/cache/backends/redis.py
@@ -34,7 +34,8 @@ class RedisCacheBackend:
         try:
             import redis.asyncio as aioredis
         except ImportError as e:
-            raise ImportError("redis non installé — pip install redis[asyncio]") from e
+            raise ImportError(
+                "redis non installé — pip install redis[asyncio]") from e
         self._client = aioredis.from_url(self._url, decode_responses=True)
         await self._client.ping()
 
@@ -53,7 +54,8 @@ class RedisCacheBackend:
 
     async def set(self, key: str, value: Any, ttl: int | None = None) -> None:
         ex = ttl if ttl is not None else self._ttl
-        raw = json.dumps(value) if not isinstance(value, (str, bytes)) else value
+        raw = json.dumps(value) if not isinstance(
+            value, (str, bytes)) else value
         await self._client.set(key, raw, ex=ex if ex > 0 else None)
 
     async def mget(self, keys: list[str]) -> dict[str, Any]:
@@ -80,7 +82,8 @@ class RedisCacheBackend:
         async with self._client.pipeline() as pipe:
             for key, value in mapping.items():
                 raw = (
-                    json.dumps(value) if not isinstance(value, (str, bytes)) else value
+                    json.dumps(value) if not isinstance(
+                        value, (str, bytes)) else value
                 )
                 pipe.set(key, raw, ex=ex if ex > 0 else None)
             await pipe.execute()

--- a/xcore/services/cache/service.py
+++ b/xcore/services/cache/service.py
@@ -48,7 +48,8 @@ class CacheService(BaseService):
 
         if backend_type == "redis":
             if not self._config.url:
-                raise ValueError("CacheConfig.url obligatoire pour le backend Redis")
+                raise ValueError(
+                    "CacheConfig.url obligatoire pour le backend Redis")
             from .backends.redis import RedisCacheBackend
 
             self._backend = RedisCacheBackend(

--- a/xcore/services/database/adapters/async_sql.py
+++ b/xcore/services/database/adapters/async_sql.py
@@ -32,7 +32,8 @@ class AsyncSQLAdapter:
 
     async def connect(self) -> None:
         try:
-            from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+            from sqlalchemy.ext.asyncio import (AsyncSession,
+                                                create_async_engine)
             from sqlalchemy.orm import sessionmaker
         except ImportError as e:
             raise ImportError(

--- a/xcore/services/database/adapters/redis.py
+++ b/xcore/services/database/adapters/redis.py
@@ -33,7 +33,8 @@ class RedisAdapter:
         try:
             import redis.asyncio as aioredis
         except ImportError as e:
-            raise ImportError("redis non installé — pip install redis[asyncio]") from e
+            raise ImportError(
+                "redis non installé — pip install redis[asyncio]") from e
 
         pool = aioredis.ConnectionPool.from_url(
             self.url,

--- a/xcore/services/database/adapters/sql.py
+++ b/xcore/services/database/adapters/sql.py
@@ -40,7 +40,8 @@ class SQLAdapter:
             from sqlalchemy import create_engine
             from sqlalchemy.orm import sessionmaker
         except ImportError as e:
-            raise ImportError("sqlalchemy non installé — pip install sqlalchemy") from e
+            raise ImportError(
+                "sqlalchemy non installé — pip install sqlalchemy") from e
 
         self._engine = create_engine(
             self.url,

--- a/xcore/services/database/migrations.py
+++ b/xcore/services/database/migrations.py
@@ -37,7 +37,8 @@ class MigrationRunner:
         try:
             from alembic.config import Config  # type:ignore
         except ImportError as e:
-            raise ImportError("alembic non installé — pip install alembic") from e
+            raise ImportError(
+                "alembic non installé — pip install alembic") from e
 
         cfg = Config()
         cfg.set_main_option("sqlalchemy.url", self.db_url)

--- a/xcore/services/scheduler/service.py
+++ b/xcore/services/scheduler/service.py
@@ -77,7 +77,8 @@ class SchedulerService(BaseService):
 
                 jobstores["default"] = RedisJobStore()
             except ImportError:
-                logger.warning("apscheduler[redis] not install — fallback memory")
+                logger.warning(
+                    "apscheduler[redis] not install — fallback memory")
 
         self._scheduler = AsyncIOScheduler(
             jobstores=jobstores,
@@ -111,7 +112,8 @@ class SchedulerService(BaseService):
                 **kwargs,
             )
         except Exception as e:
-            logger.error(f"Impossible de charger le job '{job_cfg.get('id')}' : {e}")
+            logger.error(
+                f"Impossible de charger le job '{job_cfg.get('id')}' : {e}")
 
     # ── API publique ──────────────────────────────────────────
 


### PR DESCRIPTION
add plugin middleware adding for application

## Summary by Sourcery

Enable plugin-defined middlewares to be collected at load time and mounted onto the FastAPI application, and apply broad linting/import cleanups across the codebase.

New Features:
- Allow plugins to declare middlewares that are collected by the lifecycle/loader layer and attached to the FastAPI app at startup.

Enhancements:
- Extend the base plugin contract and runtime supervisor/loader to expose and aggregate plugin middlewares for application wiring.
- Clean up imports, formatting, and minor logging/messages throughout kernel, CLI, security, and service modules for lint compliance.

Build:
- Update dev tooling configuration, including bumping the isort development dependency version.

Tests:
- Adjust unit tests for permissions, security validation, sandbox worker, lifecycle, registry, and container health to match new imports and linting rules, and keep middleware pipeline tests aligned with the middleware API.