### PR TITLE
transformation du middleware en state app

### DIFF
--- a/integration.yaml
+++ b/integration.yaml
@@ -15,10 +15,10 @@ plugins:
   directory: ./app
 
   # Clé HMAC-SHA256 utilisée pour vérifier plugin.sig
-  secret_key: "hiuhihihi"
+  secret_key: "123456"
 
   # true = refuse tout plugin Trusted non signé
-  strict_trusted: false
+  strict_trusted: true
 
   # Intervalle du watcher de rechargement à chaud (secondes)
   # Mettre à 0 pour désactiver en prod si tu gères les reloads via API
@@ -74,21 +74,6 @@ services:
     #    minutes: 5
 
   # ── Observabilité ─────────────────────────────────────────────
-
-  extensions:
-    email:
-      module: extensions.email.email:EmailService
-      config:
-        smtp_host: mail.tangagroup.com #smtp.gmail.com
-        smtp_port: 465 #587
-        smtp_user: 200
-        smtp_password: l4hgj45j43j5rn
-        from_address: traoreera@gmail.com
-        from_name: "Mon Application"
-        use_tls: true
-        timeout: 10
-        max_retries: 3
-        queue_size: 100
 
 observability:
   logging:

--- a/xcore/__init__.py
+++ b/xcore/__init__.py
@@ -21,8 +21,13 @@ from .__version__ import __version__
 from .kernel.api.contract import BasePlugin, TrustedBase
 from .kernel.events.bus import EventBus
 from .kernel.events.hooks import HookManager
-from .kernel.observability import (HealthChecker, MetricsRegistry, Tracer,
-                                   configure_logging, get_logger)
+from .kernel.observability import (
+    HealthChecker,
+    MetricsRegistry,
+    Tracer,
+    configure_logging,
+    get_logger,
+)
 from .kernel.runtime.lifecycle import LifecycleManager
 from .kernel.runtime.loader import PluginLoader
 from .kernel.runtime.supervisor import PluginSupervisor
@@ -209,11 +214,10 @@ class Xcore:
                 f"sous {wrapper.prefix}"
             )
 
-        for middleware in self.plugins.collect_middlewares():
-            app.add_middleware(
-                middleware.get("middleware", middleware.get(
-                    "handler", lambda: None)),
-                **middleware.get("params", middleware.get("option", {})),
+        for middleware in self.plugins.collect_app_state():
+            if middleware:
+                app.state.__setattr__(
+                key=f"{middleware['name']}", value=middleware["state"]
             )
 
         app.openapi_schema = None  # force la regen du schéma OpenAPI

--- a/xcore/kernel/api/contract.py
+++ b/xcore/kernel/api/contract.py
@@ -125,8 +125,7 @@ class TrustedBase(ABC):
         payload: dict | None = None,
     ) -> dict:
         if self.ctx is None:
-            raise RuntimeError(
-                "call_plugin appelé avant injection du contexte.")
+            raise RuntimeError("call_plugin appelé avant injection du contexte.")
         if self.ctx.caller is None:
             raise RuntimeError(
                 f"[{self.ctx.name}] call_plugin() non disponible "
@@ -149,8 +148,7 @@ class TrustedBase(ABC):
     def get_service(self, name: "Literal['mongodb']") -> "MongoDBAdapter": ...
 
     @overload
-    def get_service(
-        self, name: "Literal['redisAdapter']") -> "RedisAdapter": ...
+    def get_service(self, name: "Literal['redisAdapter']") -> "RedisAdapter": ...
 
     @overload
     def get_service(self, name: "Literal['syncdb']") -> "SQLAdapter": ...
@@ -232,13 +230,12 @@ class TrustedBase(ABC):
     @abstractmethod
     async def handle(self, action: str, payload: dict) -> dict: ...
 
-    def add_middleware(self) -> dict:
+    def add_state(self) -> dict:
         """
         Ajoute un middleware à l'exécution.
         :return: {
             "name": str,
-            "middleware": Middleware_class,
-            "params": dict,
+            "state": app_state
         }
 
         """

--- a/xcore/kernel/runtime/lifecycle.py
+++ b/xcore/kernel/runtime/lifecycle.py
@@ -314,7 +314,7 @@ class LifecycleManager:
             logger.error(f"[{self.manifest.name}] get_router() erreur : {e}")
 
     def _collect_middlewares(self) -> None:
-        add_middlewares = getattr(self._instance, "add_middleware", None)
+        add_middlewares = getattr(self._instance, "add_state", None)
         if add_middlewares is None:
             return
 
@@ -331,6 +331,7 @@ class LifecycleManager:
                 )
         except Exception as e:
             logger.error(f"[{self.manifest.name}] get_middlewares() erreur : {e}")
+            print(e)
 
     # ── Propagation des services (fix #3 v1) ──────────────────
 

--- a/xcore/kernel/runtime/loader.py
+++ b/xcore/kernel/runtime/loader.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from ..context import KernelContext
 
 from ...kernel.security.validation import ManifestValidator
+
 # from ...sdk.plugin_base import PluginDependency
 from ..api.contract import PluginHandler
 from .activator import ActivatorRegistry, SandboxedActivator, TrustedActivator
@@ -69,8 +70,7 @@ class PluginLoader:
         # Activator registry (Strategy Pattern)
         self._activators = ActivatorRegistry()
         self._activators.register(ExecutionMode.TRUSTED, TrustedActivator())
-        self._activators.register(
-            ExecutionMode.SANDBOXED, SandboxedActivator())
+        self._activators.register(ExecutionMode.SANDBOXED, SandboxedActivator())
         self._activators.register(ExecutionMode.LEGACY, TrustedActivator())
 
         self._validator = ManifestValidator()
@@ -212,16 +212,14 @@ class PluginLoader:
     async def load(self, plugin_name: str) -> None:
         plugin_dir = Path(self._config.directory) / plugin_name
         if not plugin_dir.is_dir():
-            raise FileNotFoundError(
-                f"Dossier plugin introuvable : {plugin_dir}")
+            raise FileNotFoundError(f"Dossier plugin introuvable : {plugin_dir}")
 
         manifest = self._validator.load_and_validate(plugin_dir)
 
         for dep in manifest.requires:
             dep_name = dep.name if hasattr(dep, "name") else str(dep)
             if dep_name not in self._handlers:
-                logger.info(
-                    f"[{plugin_name}] Dépendance '{dep_name}' → chargement...")
+                logger.info(f"[{plugin_name}] Dépendance '{dep_name}' → chargement...")
                 await self.load(dep_name)
 
         await self._activate(manifest)
@@ -256,8 +254,7 @@ class PluginLoader:
         if name in self._handlers:
             return self._handlers[name]
         available = sorted(list(self._handlers.keys()))
-        raise KeyError(
-            f"Plugin '{name}' non trouvé. Disponibles : {available}")
+        raise KeyError(f"Plugin '{name}' non trouvé. Disponibles : {available}")
 
     def has(self, name: str) -> bool:
         return name in self._handlers
@@ -292,8 +289,7 @@ class PluginLoader:
                 # dep est un PluginDependency object
                 dep_name = dep.name if hasattr(dep, "name") else str(dep)
                 if dep_name not in graph:
-                    raise ValueError(
-                        f"[{m.name}] Missing dependency '{dep_name}'")
+                    raise ValueError(f"[{m.name}] Missing dependency '{dep_name}'")
                 graph.add_dependency(m.name, dep_name)
 
         return graph.get_ordered()
@@ -326,7 +322,7 @@ class PluginLoader:
                 routers.append((name, handler.plugin_router))
         return routers
 
-    def collect_middlewares(self) -> list[Any]:
+    def collect_app_state(self) -> list[Any]:
         """
         Collecte tous les middlewares exposés par les plugins chargés.
 
@@ -341,4 +337,7 @@ class PluginLoader:
                 and handler.plugin_middlewares is not None
             ):
                 middlewares.append(handler.plugin_middlewares)
-        return middlewares
+        try:
+            return middlewares[0]
+        except:
+            return middlewares

--- a/xcore/kernel/runtime/supervisor.py
+++ b/xcore/kernel/runtime/supervisor.py
@@ -17,9 +17,15 @@ if TYPE_CHECKING:
 from ..permissions.engine import PermissionEngine
 from ..sandbox.limits import RateLimiterRegistry
 from .loader import PluginLoader
-from .middlewares import (Middleware, MiddlewarePipeline, MiddlewareRegistry,
-                          PermissionMiddleware, RateLimitMiddleware,
-                          RetryMiddleware, TracingMiddleware)
+from .middlewares import (
+    Middleware,
+    MiddlewarePipeline,
+    MiddlewareRegistry,
+    PermissionMiddleware,
+    RateLimitMiddleware,
+    RetryMiddleware,
+    TracingMiddleware,
+)
 
 logger = logging.getLogger("xcore.runtime.supervisor")
 
@@ -63,18 +69,15 @@ class PluginSupervisor:
         """Registers default middleware factories."""
         self._middleware_registry.register(
             "tracing",
-            lambda ctx: TracingMiddleware(
-                ctx.get("tracer"), ctx.get("metrics")),
+            lambda ctx: TracingMiddleware(ctx.get("tracer"), ctx.get("metrics")),
         )
         self._middleware_registry.register(
             "rate_limit", lambda ctx: RateLimitMiddleware(ctx.get("rate"))
         )
         self._middleware_registry.register(
-            "permissions", lambda ctx: PermissionMiddleware(
-                ctx.get("permissions"))
+            "permissions", lambda ctx: PermissionMiddleware(ctx.get("permissions"))
         )
-        self._middleware_registry.register(
-            "retry", lambda _: RetryMiddleware())
+        self._middleware_registry.register("retry", lambda _: RetryMiddleware())
 
     async def boot(self) -> None:
         """Instancie le loader et charge tous les plugins."""
@@ -86,8 +89,7 @@ class PluginSupervisor:
 
         self._loader = PluginLoader(
             ctx=self._ctx,
-            caller=lambda name, action, payload: self.call(
-                name, action, payload),
+            caller=lambda name, action, payload: self.call(name, action, payload),
         )
         report = await self._loader.load_all()
         logger.info(
@@ -144,8 +146,7 @@ class PluginSupervisor:
                         f"[{name}] Rate limit : {rl.calls}/{rl.period_seconds}s"
                     )
             except Exception as e:
-                logger.error(
-                    f"[{name}] Erreur enregistrement rate limit : {e}")
+                logger.error(f"[{name}] Erreur enregistrement rate limit : {e}")
 
     async def _on_plugin_services_registered(self, event) -> None:
         """Handler réactif appelé quand un plugin a enregistré ses services."""
@@ -164,8 +165,7 @@ class PluginSupervisor:
         # 3. Enregistrement dans le registry si disponible
         if self._registry and self._loader:
             with contextlib.suppress(KeyError):
-                self._registry.register(
-                    plugin_name, self._loader.get(plugin_name))
+                self._registry.register(plugin_name, self._loader.get(plugin_name))
 
     def _load_permissions(self, plugin_names: list[str]) -> None:
         """Charge les policies de chaque plugin dans le PermissionEngine."""
@@ -264,8 +264,8 @@ class PluginSupervisor:
     def collect_plugin_routers(self) -> list[tuple[str, Any]]:
         return self._loader.collect_plugin_routers() if self._loader else []
 
-    def collect_middlewares(self) -> list[Any]:
-        return self._loader.collect_middlewares() if self._loader else []
+    def collect_app_state(self) -> list[Any]:
+        return self._loader.collect_app_state() if self._loader else []
 
     def permissions_status(self) -> dict:
         """Expose l'état du moteur de permissions (audit log + policies)."""


### PR DESCRIPTION
transformation du middleware en state app pour enregistre des etat de l'app et des plugins aussi facilement

## Summary by Sourcery

Transition plugin-exposed middlewares to an application state mechanism and adjust plugin loading and lifecycle to use the new API.

Enhancements:
- Replace plugin middleware collection with app state collection and wire it into application initialization via app.state attributes instead of FastAPI middlewares.
- Rename plugin hook from add_middleware to add_state and propagate this change through the lifecycle and loader APIs.
- Improve logging and error messages formatting in runtime components for readability.

Build:
- Tighten integration environment configuration by updating the plugin secret key and enabling strict verification of trusted plugins, and remove the sample email extension configuration from the integration manifest.