### PR TITLE
ajoue du plugin virtuel `kernel`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ integration.yaml
 /app
 main.py
 /log
+
+summaries.json

--- a/docgen/config.yaml
+++ b/docgen/config.yaml
@@ -10,12 +10,12 @@ cache:
 model:
   base_url: http://localhost:11434/v1
   api_key: lm-studio
-  model_name: novaforgeai/deepseek-coder:6.7b-optimized
+  model_name: qwen2.5-coder:1.5b-instruct
   temperature: 0.1
 
 generation:
   max_file_chunk_chars: 8000
-  include_extensions: [".py", ".yaml", ".json", ".md"]
+  include_extensions: [".py", ".yaml", ".json", ".md", '.cpp']
   exclude_dirs:
     [
       ".git",

--- a/xcore/__init__.py
+++ b/xcore/__init__.py
@@ -21,13 +21,8 @@ from .__version__ import __version__
 from .kernel.api.contract import BasePlugin, TrustedBase
 from .kernel.events.bus import EventBus
 from .kernel.events.hooks import HookManager
-from .kernel.observability import (
-    HealthChecker,
-    MetricsRegistry,
-    Tracer,
-    configure_logging,
-    get_logger,
-)
+from .kernel.observability import (HealthChecker, MetricsRegistry, Tracer,
+                                   configure_logging, get_logger)
 from .kernel.runtime.lifecycle import LifecycleManager
 from .kernel.runtime.loader import PluginLoader
 from .kernel.runtime.supervisor import PluginSupervisor
@@ -110,8 +105,8 @@ class Xcore:
         self._logger.info(f"━━━ xcore v{__version__} démarrage ━━━")
 
         # 0. Validation clés secrètes en production
-        if self._config.app.env == "production":
-            self._validate_secret_keys()
+
+        self._validate_secret_keys()
 
         # etape intermediare
         # configuration de l'observabilite
@@ -148,6 +143,7 @@ class Xcore:
         )
         self.plugins = PluginSupervisor(ctx)
         await self.plugins.boot()
+        self.plugins_lists = self.plugins.list_plugins()
 
         # 5. Attache le router FastAPI si une app est fournie
         if app is not None:
@@ -232,7 +228,10 @@ class Xcore:
         if self._config.app.env != "production":
             return
         default_key = b"change-me-in-production"
-        if self._config.app.secret_key == default_key:
+        if (
+            self._config.app.secret_key == default_key
+            or self._config.app.server_key == default_key
+        ):
             raise RuntimeError(
                 "SECRET_KEY par défaut détecté en production ! "
                 "Configurez app.secret_key dans votre xcore.yaml"

--- a/xcore/configurations/loader.py
+++ b/xcore/configurations/loader.py
@@ -35,10 +35,10 @@ class ConfigLoader:
     """
 
     DEFAULT_PATHS = [
-        Path("xcore.yaml"),
-        Path("xcore.yml"),
-        Path("xcore.json"),
-        Path("config/xcore.yaml"),
+        Path("integation.yaml"),
+        Path("integation.yml"),
+        Path("integation.json"),
+        Path("config/integation.yaml"),
     ]
 
     @classmethod
@@ -141,7 +141,7 @@ class ConfigLoader:
             secret_key=sk,
             plugin_prefix=d.get("plugin_prefix", "/plugin"),
             plugin_tags=d.get("plugin_tags", []),
-            server_key=d.get("server_key"),
+            server_key=d.get("server_key", 'change-me-in-production'),
             server_key_iterations=d.get("server_key_iterations", 100000),
         )
 

--- a/xcore/kernel/api/contract.py
+++ b/xcore/kernel/api/contract.py
@@ -125,7 +125,8 @@ class TrustedBase(ABC):
         payload: dict | None = None,
     ) -> dict:
         if self.ctx is None:
-            raise RuntimeError("call_plugin appelé avant injection du contexte.")
+            raise RuntimeError(
+                "call_plugin appelé avant injection du contexte.")
         if self.ctx.caller is None:
             raise RuntimeError(
                 f"[{self.ctx.name}] call_plugin() non disponible "
@@ -148,7 +149,8 @@ class TrustedBase(ABC):
     def get_service(self, name: "Literal['mongodb']") -> "MongoDBAdapter": ...
 
     @overload
-    def get_service(self, name: "Literal['redisAdapter']") -> "RedisAdapter": ...
+    def get_service(
+        self, name: "Literal['redisAdapter']") -> "RedisAdapter": ...
 
     @overload
     def get_service(self, name: "Literal['syncdb']") -> "SQLAdapter": ...

--- a/xcore/kernel/runtime/kernel_handler.py
+++ b/xcore/kernel/runtime/kernel_handler.py
@@ -1,0 +1,79 @@
+# xcore/kernel/runtime/kernel_handler.py
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from supervisor import PluginSupervisor
+
+    from ..context import KernelContext
+
+from .state_machine import PluginState
+
+
+class KernelHandler:
+    """
+    Plugin virtuel 'xcore' — expose les internals du kernel via l'IPC existant.
+
+    Appel : supervisor.call("xcore", "plugins.list", {})
+            supervisor.call("xcore", "metrics.snapshot", {})
+            supervisor.call("xcore", "health.run", {})
+            supervisor.call("xcore", "permissions.audit", {"plugin": "my_plugin"})
+            supervisor.call("xcore", "registry.services", {})
+    """
+
+    # Sentinel — jamais en FAILED/UNLOADED, toujours READY
+    state = PluginState.READY
+
+    def __init__(self, ctx: "KernelContext", supervisor: "PluginSupervisor") -> None:
+        self._ctx = ctx
+        self._supervisor = supervisor  # ref circulaire volontaire (weak si besoin)
+
+    @property
+    def is_available(self) -> bool:
+        return True
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+    def status(self) -> dict[str, Any]:
+        return {"name": "xcore", "mode": "kernel", "state": "ready"}
+
+    # ── Dispatch ──────────────────────────────────────────────
+
+    async def call(self, action: str, payload: dict) -> dict:
+        handler = self._ACTIONS.get(action)
+        if handler is None:
+            available = sorted(self._ACTIONS.keys())
+            return {
+                "status": "error",
+                "msg": f"Action kernel inconnue : '{action}'",
+                "code": "unknown_action",
+                "available": available,
+            }
+        try:
+            return await handler(self, payload)
+        except Exception as e:
+            return {"status": "error", "msg": str(e), "code": "kernel_error"}
+
+    # ── Actions ───────────────────────────────────────────────
+
+    async def _plugins_list(self, payload: dict) -> dict:
+        return {
+            "status": "ok",
+            "plugins": self._supervisor.list_plugins(),
+        }
+
+    # ── Table de dispatch ─────────────────────────────────────
+
+    _ACTIONS: dict = {}  # rempli ci-dessous
+
+
+# Enregistrement déclaratif (évite les répétitions de string)
+KernelHandler._ACTIONS = {
+    "plugin.list": KernelHandler._plugins_list,
+}

--- a/xcore/kernel/runtime/lifecycle.py
+++ b/xcore/kernel/runtime/lifecycle.py
@@ -38,7 +38,8 @@ class LifecycleManager:
     Manages the complete lifecycle of a Trusted plugin in memory.
     """
 
-    PROTECTED_SERVICES = {"db", "cache", "scheduler", "events", "hooks", "database"}
+    PROTECTED_SERVICES = {"db", "cache",
+                          "scheduler", "events", "hooks", "database"}
 
     def __init__(
         self,
@@ -84,7 +85,8 @@ class LifecycleManager:
         return None if self._loaded_at is None else time.monotonic() - self._loaded_at
 
     def _on_state_change(self, old: PluginState, new: PluginState) -> None:
-        logger.debug(f"[{self.manifest.name}] état : {old.value} → {new.value}")
+        logger.debug(
+            f"[{self.manifest.name}] état : {old.value} → {new.value}")
         if self._events:
             self._events.emit_sync(
                 f"plugin.{self.manifest.name}.state_changed",
@@ -116,7 +118,8 @@ class LifecycleManager:
             )
         except Exception as e:
             self._sm.transition("error")
-            raise LoadError(f"[{self.manifest.name}] Échec chargement : {e}") from e
+            raise LoadError(
+                f"[{self.manifest.name}] Échec chargement : {e}") from e
 
     async def _do_load(self) -> None:
         entry = self.manifest.plugin_dir / self.manifest.entry_point
@@ -184,7 +187,8 @@ class LifecycleManager:
                     else:
                         hook()
                 except Exception as e:
-                    logger.error(f"[{self.manifest.name}] Erreur hook {name} : {e}")
+                    logger.error(
+                        f"[{self.manifest.name}] Erreur hook {name} : {e}")
                     raise
 
     def _instantiate(self, cls) -> BasePlugin:
@@ -241,7 +245,8 @@ class LifecycleManager:
             raise
 
         return (
-            result if isinstance(result, dict) else {"status": "ok", "result": result}
+            result if isinstance(result, dict) else {
+                "status": "ok", "result": result}
         )
 
     # ── Reload ────────────────────────────────────────────────
@@ -259,7 +264,8 @@ class LifecycleManager:
             logger.info(f"[{self.manifest.name}] reloaded")
         except Exception as e:
             self._sm.transition("error")
-            raise LoadError(f"[{self.manifest.name}] failed reload : {e}") from e
+            raise LoadError(
+                f"[{self.manifest.name}] failed reload : {e}") from e
 
     # ── Unload ────────────────────────────────────────────────
 
@@ -330,8 +336,8 @@ class LifecycleManager:
                     f"({len(self.plugin_middlewares)} middleware(s))"
                 )
         except Exception as e:
-            logger.error(f"[{self.manifest.name}] get_middlewares() erreur : {e}")
-            print(e)
+            logger.error(
+                f"[{self.manifest.name}] get_middlewares() erreur : {e}")
 
     # ── Propagation des services (fix #3 v1) ──────────────────
 
@@ -383,7 +389,8 @@ class LifecycleManager:
         else:
             # Fallback de sécurité si le registre est absent (pour les tests ou configs minimales)
             # On définit une liste minimale de services à protéger
-            protected = {"db", "cache", "scheduler", "events", "hooks", "database"}
+            protected = {"db", "cache", "scheduler",
+                         "events", "hooks", "database"}
             collisions = set(instance_services.keys()) & protected
             if collisions:
                 raise PermissionError(
@@ -410,7 +417,8 @@ class LifecycleManager:
                 f"{sorted(instance_services.keys())}"
             )
         else:
-            new_keys = set(instance_services.keys()) - set(self._services.keys())
+            new_keys = set(instance_services.keys()) - \
+                set(self._services.keys())
             for k in new_keys:
                 self._services[k] = instance_services[k]
             if new_keys:

--- a/xcore/kernel/runtime/loader.py
+++ b/xcore/kernel/runtime/loader.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from ..context import KernelContext
 
 from ...kernel.security.validation import ManifestValidator
-
 # from ...sdk.plugin_base import PluginDependency
 from ..api.contract import PluginHandler
 from .activator import ActivatorRegistry, SandboxedActivator, TrustedActivator
@@ -70,7 +69,8 @@ class PluginLoader:
         # Activator registry (Strategy Pattern)
         self._activators = ActivatorRegistry()
         self._activators.register(ExecutionMode.TRUSTED, TrustedActivator())
-        self._activators.register(ExecutionMode.SANDBOXED, SandboxedActivator())
+        self._activators.register(
+            ExecutionMode.SANDBOXED, SandboxedActivator())
         self._activators.register(ExecutionMode.LEGACY, TrustedActivator())
 
         self._validator = ManifestValidator()
@@ -212,14 +212,16 @@ class PluginLoader:
     async def load(self, plugin_name: str) -> None:
         plugin_dir = Path(self._config.directory) / plugin_name
         if not plugin_dir.is_dir():
-            raise FileNotFoundError(f"Dossier plugin introuvable : {plugin_dir}")
+            raise FileNotFoundError(
+                f"Dossier plugin introuvable : {plugin_dir}")
 
         manifest = self._validator.load_and_validate(plugin_dir)
 
         for dep in manifest.requires:
             dep_name = dep.name if hasattr(dep, "name") else str(dep)
             if dep_name not in self._handlers:
-                logger.info(f"[{plugin_name}] Dépendance '{dep_name}' → chargement...")
+                logger.info(
+                    f"[{plugin_name}] Dépendance '{dep_name}' → chargement...")
                 await self.load(dep_name)
 
         await self._activate(manifest)
@@ -254,7 +256,8 @@ class PluginLoader:
         if name in self._handlers:
             return self._handlers[name]
         available = sorted(list(self._handlers.keys()))
-        raise KeyError(f"Plugin '{name}' non trouvé. Disponibles : {available}")
+        raise KeyError(
+            f"Plugin '{name}' non trouvé. Disponibles : {available}")
 
     def has(self, name: str) -> bool:
         return name in self._handlers
@@ -289,7 +292,8 @@ class PluginLoader:
                 # dep est un PluginDependency object
                 dep_name = dep.name if hasattr(dep, "name") else str(dep)
                 if dep_name not in graph:
-                    raise ValueError(f"[{m.name}] Missing dependency '{dep_name}'")
+                    raise ValueError(
+                        f"[{m.name}] Missing dependency '{dep_name}'")
                 graph.add_dependency(m.name, dep_name)
 
         return graph.get_ordered()

--- a/xcore/kernel/runtime/middlewares/__init__.py
+++ b/xcore/kernel/runtime/middlewares/__init__.py
@@ -7,10 +7,10 @@ from .tracing import TracingMiddleware
 
 __all__ = [
     "Middleware",
-    " MiddlewarePipeline",
-    " MiddlewareRegistry",
-    " PermissionMiddleware",
-    " RateLimitMiddleware",
-    " RetryMiddleware",
-    " TracingMiddleware",
+    "MiddlewarePipeline",
+    "MiddlewareRegistry",
+    "PermissionMiddleware",
+    "RateLimitMiddleware",
+    "RetryMiddleware",
+    "TracingMiddleware",
 ]

--- a/xcore/kernel/runtime/middlewares/tracing.py
+++ b/xcore/kernel/runtime/middlewares/tracing.py
@@ -44,10 +44,12 @@ class TracingMiddleware(Middleware):
 
         # Span de tracing optionnel
         if self._tracer:
-            async with self._tracer.span(f"{plugin_name}.{action}") as span:
+            with self._tracer.span(f"{plugin_name}.{action}") as span:
                 span.set_attribute("plugin", plugin_name)
                 span.set_attribute("action", action)
-                result = await next_call(plugin_name, action, payload, handler, **kwargs)
+                result = await next_call(
+                    plugin_name, action, payload, handler, **kwargs
+                )
 
                 if isinstance(result, dict) and result.get("status") == "error":
                     span.set_status("error")

--- a/xcore/kernel/runtime/supervisor.py
+++ b/xcore/kernel/runtime/supervisor.py
@@ -97,6 +97,15 @@ class PluginSupervisor:
             f"échecs: {len(report['failed'])}, ignorés: {len(report['skipped'])}"
         )
 
+        # kernel virtual handler
+        from .kernel_handler import KernelHandler
+
+        self._loader._handlers["kernel"] = KernelHandler(self._ctx, self)
+        self._permissions.grant_all("kernel")
+        from ..sandbox.limits import RateLimitConfig
+
+        self._rate.register("kernel", RateLimitConfig(calls=10_000, period_seconds=60))
+
         # Enregistrement des services noyau comme "protégés" dans le registre
         if self._registry:
             for name, svc in self._services.as_dict().items():
@@ -126,6 +135,7 @@ class PluginSupervisor:
 
         if self._events:
             await self._events.emit("xcore.plugins.booted", {"report": report})
+        return report
 
     def _register_rate_limits(self, plugin_names: list[str]) -> None:
         """Enregistre les rate limits de chaque plugin dans le RateLimiterRegistry."""

--- a/xcore/kernel/security/validation.py
+++ b/xcore/kernel/security/validation.py
@@ -31,11 +31,8 @@ from .section import (DEFAULT_ALLOWED, DEFAULT_FORBIDDEN, FORBIDDEN_ATTRIBUTES,
 try:
     from .scanner_core import \
         ImportClassifier as _CppClassifier  # type: ignore
-
-    print("AST-> Cpp Classifier")
     _CPP_AVAILABLE = True
 except ImportError:
-    print("AST-> python Classifier")
     _CppClassifier = None
     _CPP_AVAILABLE = False
 
@@ -87,8 +84,7 @@ class ManifestValidator:
     def load_and_validate(self, plugin_dir: Path):
         from xcore import __version__
 
-        from ..api.contract import ExecutionMode
-        from ..api.versioning import check_compatibility
+        from ..api import ExecutionMode, check_compatibility
 
         plugin_dir = Path(plugin_dir).resolve()
         raw = self._read_raw(plugin_dir)


### PR DESCRIPTION
pour prendre en charge certain command
maj du tracing qui plantain cause de `async with`
maj des default path de `xcore.*` a `integration.*` supression des `print` pour preproduction

## Summary by Sourcery

Add a virtual kernel plugin to expose internal kernel operations over the existing IPC and adjust configuration, security, and tracing behavior accordingly.

New Features:
- Introduce a virtual `kernel` plugin handler that exposes kernel internals via the existing plugin call interface (e.g., plugin listing).

Enhancements:
- Register and fully authorize the `kernel` virtual handler during plugin supervisor boot and return the boot report.
- Always run secret key validation during boot (while still no-oping outside production) and extend it to validate both app and server keys against the default value.
- Update configuration loading defaults to use `integration.*` config files and provide a default `server_key` value when missing.
- Adjust tracing middleware to use a non-async span context manager to avoid issues with `async with` usage.
- Simplify manifest validation imports by using the consolidated kernel API module.
- Expose the list of loaded plugins on the `Xcore` instance after boot for easier access.
- Tidy middleware exports, logging messages, and formatting, and remove preproduction `print` statements from runtime and security modules.
- Extend documentation generation config to target a different default model and include C++ sources in generation.