### PR TITLE
fixing bug database container

### DIFF
--- a/xcore/services/database/adapters/_utils.py
+++ b/xcore/services/database/adapters/_utils.py
@@ -1,8 +1,5 @@
 """
-_utils.py — Normalisation des connect_args selon le driver SQL.
-
-Chaque driver DBAPI a ses propres paramètres de connexion acceptés.
-Passer un argument inconnu lève une TypeError au connect().
+_utils.py — Normalisation des connect_args et isolation_level selon le driver SQL.
 """
 
 from __future__ import annotations
@@ -11,9 +8,7 @@ import logging
 
 logger = logging.getLogger("xcore.services.database")
 
-# Paramètres valides par driver (ceux qu'on expose dans xcore.yaml)
 _VALID_CONNECT_ARGS: dict[str, set[str]] = {
-    # aiomysql / pymysql / mysqlclient
     "aiomysql": {
         "connect_timeout",
         "charset",
@@ -35,7 +30,6 @@ _VALID_CONNECT_ARGS: dict[str, set[str]] = {
         "ssl_cert",
         "ssl_key",
     },
-    # asyncpg / psycopg2 / psycopg3
     "asyncpg": {
         "timeout",
         "command_timeout",
@@ -51,41 +45,92 @@ _VALID_CONNECT_ARGS: dict[str, set[str]] = {
         "sslrootcert",
         "application_name",
     },
-    "psycopg": {  # psycopg3
+    "psycopg": {
         "connect_timeout",
         "options",
         "sslmode",
         "application_name",
     },
-    # aiosqlite / sqlite
     "aiosqlite": {"timeout", "check_same_thread", "uri"},
     "pysqlite": {"timeout", "check_same_thread", "uri"},
 }
 
+# Isolation levels valides par famille de BDD
+_VALID_ISOLATION_LEVELS: dict[str, set[str]] = {
+    "sqlite": {"READ UNCOMMITTED", "SERIALIZABLE", "AUTOCOMMIT"},
+    "mysql": {
+        "READ UNCOMMITTED",
+        "READ COMMITTED",
+        "REPEATABLE READ",
+        "SERIALIZABLE",
+        "AUTOCOMMIT",
+    },
+    "postgresql": {
+        "READ UNCOMMITTED",
+        "READ COMMITTED",
+        "REPEATABLE READ",
+        "SERIALIZABLE",
+        "AUTOCOMMIT",
+    },
+}
 
-def _detect_driver(url: str) -> str:
-    """Détecte le driver depuis l'URL SQLAlchemy."""
+
+def detect_driver(url: str) -> str:
+    """
+    Détecte le driver depuis l'URL SQLAlchemy.
+    Ex: 'mysql+aiomysql://...' → 'aiomysql'
+        'sqlite+aiosqlite://...' → 'aiosqlite'
+        'postgresql+asyncpg://...' → 'asyncpg'
+    """
     url_lower = url.lower()
-    for driver in _VALID_CONNECT_ARGS:
+
+    # Ordre important : tester les drivers spécifiques avant les génériques
+    driver_tokens = [
+        "aiomysql",
+        "pymysql",
+        "asyncpg",
+        "aiosqlite",
+        "psycopg2",
+        "psycopg",
+        "pysqlite",
+        "mysqlconnector",
+        "cymysql",
+    ]
+    for driver in driver_tokens:
         if driver in url_lower:
             return driver
-    # Fallback : on ne filtre pas
+
+    return ""
+
+
+def detect_db_family(url: str) -> str:
+    """
+    Détecte la famille de BDD pour la validation de l'isolation_level.
+    Ex: 'mysql+aiomysql://...' → 'mysql'
+    """
+    url_lower = url.lower()
+    if url_lower.startswith("sqlite"):
+        return "sqlite"
+    if url_lower.startswith("mysql") or url_lower.startswith("mariadb"):
+        return "mysql"
+    if url_lower.startswith("postgresql") or url_lower.startswith("postgres"):
+        return "postgresql"
     return ""
 
 
 def sanitize_connect_args(url: str, connect_args: dict) -> dict:
     """
-    Filtre connect_args pour ne garder que les clés valides pour le driver.
-    Log un warning pour chaque clé ignorée.
+    Filtre connect_args pour ne garder que les clés valides pour le driver détecté.
+    Log un warning pour chaque clé ignorée, sans planter.
     """
     if not connect_args:
         return {}
 
-    driver = _detect_driver(url)
+    driver = detect_driver(url)
     valid = _VALID_CONNECT_ARGS.get(driver)
 
-    if valid is None:
-        # Driver inconnu → on passe tout et on laisse le driver lever l'erreur
+    if not valid:
+        # Driver inconnu → on passe tout tel quel
         return connect_args
 
     filtered = {}
@@ -99,3 +144,28 @@ def sanitize_connect_args(url: str, connect_args: dict) -> dict:
             )
 
     return filtered
+
+
+def sanitize_isolation_level(url: str, isolation_level: str | None) -> str | None:
+    """
+    Valide l'isolation_level selon la famille de BDD.
+    Retourne None (ignoré silencieusement) si incompatible.
+    """
+    if not isolation_level:
+        return None
+
+    family = detect_db_family(url)
+    valid = _VALID_ISOLATION_LEVELS.get(family)
+
+    if not valid:
+        return isolation_level  # famille inconnue → on laisse passer
+
+    level_upper = isolation_level.upper()
+    if level_upper not in valid:
+        logger.warning(
+            f"isolation_level '{isolation_level}' ignoré pour '{family}' "
+            f"(non supporté). Niveaux valides : {sorted(valid)}"
+        )
+        return None
+
+    return level_upper

--- a/xcore/services/database/adapters/async_sql.py
+++ b/xcore/services/database/adapters/async_sql.py
@@ -8,6 +8,8 @@ import logging
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, AsyncGenerator
 
+from ._utils import detect_driver, sanitize_connect_args, sanitize_isolation_level
+
 if TYPE_CHECKING:
     from ....configurations.sections import DatabaseConfig
 
@@ -15,23 +17,6 @@ logger = logging.getLogger("xcore.services.database.async_sql")
 
 
 class AsyncSQLAdapter:
-    """
-    Adaptateur SQLAlchemy async — optimisé production.
-
-    Paramètres pool configurables depuis xcore.yaml :
-        pool_pre_ping        → détecte les connexions mortes avant usage (crucial MySQL)
-        pool_recycle         → renouvelle avant le wait_timeout serveur
-        pool_timeout         → timeout d'acquisition depuis le pool
-        pool_reset_on_return → comportement au retour au pool (rollback/commit/none)
-        connect_args         → timeouts driver-level (connect_timeout, read_timeout…)
-        isolation_level      → niveau d'isolation transactionnel
-        execution_options    → options SQLAlchemy par session
-
-    Usage:
-        async with adapter.session() as session:
-            result = await session.execute(text("SELECT * FROM users"))
-    """
-
     def __init__(self, name: str, cfg: "DatabaseConfig") -> None:
         self.name = name
         self.url = cfg.url
@@ -55,8 +40,6 @@ class AsyncSQLAdapter:
                 "sqlalchemy[asyncio] non installé — pip install sqlalchemy[asyncio]"
             ) from e
 
-        from ._utils import sanitize_connect_args  # ← import local
-
         engine_kwargs: dict[str, Any] = {
             "echo": self._echo,
             "pool_pre_ping": self._pool_pre_ping,
@@ -69,12 +52,14 @@ class AsyncSQLAdapter:
             if sanitized:
                 engine_kwargs["connect_args"] = sanitized
 
-        if self._isolation_level:
-            engine_kwargs["isolation_level"] = self._isolation_level
+        safe_isolation = sanitize_isolation_level(self.url, self._isolation_level)
+        if safe_isolation:
+            engine_kwargs["isolation_level"] = safe_isolation
 
         if self.url.startswith("sqlite"):
             engine_kwargs.pop("pool_timeout", None)
             engine_kwargs.pop("pool_recycle", None)
+            engine_kwargs.pop("pool_pre_ping", None)
 
         self._engine = create_async_engine(self.url, **engine_kwargs)
 
@@ -90,9 +75,10 @@ class AsyncSQLAdapter:
         async with self._engine.connect() as conn:
             await conn.execute(__import__("sqlalchemy").text("SELECT 1"))
 
+        driver = detect_driver(self.url)
         logger.info(
             f"[{self.name}] AsyncSQL connecté "
-            f"(driver={_detect_driver(self.url)}, pre_ping={self._pool_pre_ping}, "
+            f"(driver={driver}, pre_ping={self._pool_pre_ping}, "
             f"recycle={self._pool_recycle}s)"
         )
 
@@ -100,6 +86,8 @@ class AsyncSQLAdapter:
         if self._engine:
             await self._engine.dispose()
             self._engine = None
+            self._AsyncSession = None
+            logger.info(f"[{self.name}] AsyncSQL déconnecté")
 
     @asynccontextmanager
     async def session(self) -> AsyncGenerator:
@@ -112,8 +100,6 @@ class AsyncSQLAdapter:
                 yield sess
                 await sess.commit()
             except Exception:
-                # Le rollback peut échouer si la connexion est morte (MySQL wait_timeout).
-                # On l'absorbe pour laisser remonter l'exception originale proprement.
                 try:
                     await sess.rollback()
                 except Exception as rollback_err:

--- a/xcore/services/database/adapters/sql.py
+++ b/xcore/services/database/adapters/sql.py
@@ -8,6 +8,8 @@ import logging
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Generator
 
+from ._utils import sanitize_connect_args, sanitize_isolation_level
+
 if TYPE_CHECKING:
     from ....configurations.sections import DatabaseConfig
 
@@ -55,8 +57,6 @@ class SQLAdapter:
         except ImportError as e:
             raise ImportError("sqlalchemy non installé — pip install sqlalchemy") from e
 
-        from ._utils import sanitize_connect_args  # ← import local
-
         engine_kwargs: dict[str, Any] = {
             "echo": self._echo,
             "pool_pre_ping": self._pool_pre_ping,
@@ -75,8 +75,9 @@ class SQLAdapter:
             if sanitized:
                 engine_kwargs["connect_args"] = sanitized
 
-        if self._isolation_level:
-            engine_kwargs["isolation_level"] = self._isolation_level
+        safe_isolation = sanitize_isolation_level(self.url, self._isolation_level)
+        if safe_isolation:
+            engine_kwargs["isolation_level"] = safe_isolation
 
         self._engine = create_engine(self.url, **engine_kwargs)
 


### PR DESCRIPTION
## Summary by Sourcery

Validate and sanitize database driver configuration and isolation levels when creating SQLAlchemy engines for async and sync adapters.

Bug Fixes:
- Prevent passing unsupported isolation levels to database drivers by validating them per database family and ignoring invalid values.
- Avoid relying on implicit driver detection by introducing explicit driver and database family detection utilities used by SQL adapters.
- Ensure SQLite connections do not use incompatible pool options like pre_ping, pool_timeout, and pool_recycle when creating engines.
- Cleanly reset async SQL adapter state on disconnect to avoid stale engine/session references.

Enhancements:
- Centralize driver detection, connect_args sanitization, and isolation level validation utilities in the shared database adapter helpers module.
- Log clearer information about the connected driver and adapter lifecycle events for async SQL connections.