### PR TITLE
fix-bug: env dans le proto plantera si il es pas dans le context du p…

### DIFF
--- a/xcore/kernel/api/proto.py
+++ b/xcore/kernel/api/proto.py
@@ -81,7 +81,7 @@ class PluginContext:
     """
 
     name: str
-    env: dict
+    env: dict = field(default_factory=dict)
     services: dict[str, Any] = field(default_factory=dict)
     events: EventBus = None  # EventBus
     hooks: HookManager = None  # HookManager


### PR DESCRIPTION
…lugins.

## Summary by Sourcery

Bug Fixes:
- Prevent failures when a plugin context is created without an explicit env by defaulting env to an empty dictionary.