### PR TITLE
Fix/security validation naming bug frameworkversionversion

### DIFF
--- a/xcore/kernel/security/validation.py
+++ b/xcore/kernel/security/validation.py
@@ -51,7 +51,7 @@ class ManifestError(Exception):
 
 
 class FrameworkVersionError(Exception):
-    """Déclenché lorsque la contrainte framework_version d'un plugin n'est pas respectée."""
+    """Raised when a plugin's framework_version constraint is not satisfied."""
     pass
 
 

--- a/xcore/kernel/security/validation.py
+++ b/xcore/kernel/security/validation.py
@@ -54,6 +54,8 @@ class FrameworkVersionError(Exception):
     """Raised when a plugin's framework_version constraint is not satisfied."""
     pass
 
+# Alias de rétro-compatibilité — à supprimer en v-prochaine-majeure
+FrameworkVersionVersion = FrameworkVersionError
 
 _ENV_VAR_RE = re.compile(r"^\$\{(.+)\}$")
 

--- a/xcore/kernel/security/validation.py
+++ b/xcore/kernel/security/validation.py
@@ -50,7 +50,8 @@ class ManifestError(Exception):
     pass
 
 
-class FrameworkVersionVersion(Exception):
+class FrameworkVersionError(Exception):
+    """Déclenché lorsque la contrainte framework_version d'un plugin n'est pas respectée."""
     pass
 
 


### PR DESCRIPTION
**Factorisation**
Duplication du code middleware. xcore/kernel/runtime/middlewares/ et xcore/kernel/sandbox/middlewares/ contiennent les mêmes 6 fichiers (permissions.py, ratelimit.py, retry.py, tracing.py…) avec des contenus quasi-identiques (~70 lignes chacun)

## Summary by Sourcery

Bug Fixes:
- Correct the exception class name used when a plugin's framework_version constraint is not satisfied.