### PR TITLE
ajoue de prometheus-client comme dependance pour le logging

### DIFF
--- a/integration.yaml
+++ b/integration.yaml
@@ -77,10 +77,7 @@ services:
 
   # ── Cache ────────────────────────────────────────────────────
   cache:
-    backend: redis
-    url: redis://localhost:6379/0
-    ttl: 300 # TTL par défaut en secondes
-    max_size: 10000 # ignoré en mode redis, actif en mode memory
+    backend: memory
 
   # ── Scheduler ────────────────────────────────────────────────
   scheduler:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2503,6 +2503,23 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "prometheus-client"
+version = "0.25.0"
+description = "Python client for the Prometheus monitoring system."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1"},
+    {file = "prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28"},
+]
+
+[package.extras]
+aiohttp = ["aiohttp"]
+django = ["django"]
+twisted = ["twisted"]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 description = "Library for building powerful interactive command lines in Python"
@@ -4362,4 +4379,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "625396528a31d25c4931523380eab179db3b457eadff51a29f0865eac6040257"
+content-hash = "8439d56a34f4b992e77e9f6ed3fd8203b2e04b3e766a3b9c686fe4c12bfc90af"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ autoflake         = "^2.3.1"
 autopep8          = "^2.3.2"
 bandit            = "^1.8.6"
 pre-commit        = "^4.6.0"
-
+prometheus-client = { version = ">=0.25.0,<0.26.0" }
 # ── Docs dependencies ──────────────────────────────────────────────────────────
 [tool.poetry.group.docs.dependencies]
 mkdocs                = "^1.6.1"


### PR DESCRIPTION
## Summary by Sourcery

Add Prometheus client as a dependency and switch integration cache backend to in-memory storage.

New Features:
- Introduce prometheus-client library as a runtime dependency for metrics and logging integration.

Enhancements:
- Change integration environment cache configuration to use an in-memory backend instead of Redis.