### PR TITLE
Potential fix for code scanning alert no. 28: Clear-text logging of sensitive information

### DIFF
--- a/xcore/kernel/runtime/activator.py
+++ b/xcore/kernel/runtime/activator.py
@@ -23,7 +23,7 @@ class ActivatorRegistry:
 
     def register(self, mode: Any, activator: PluginActivator) -> None:
         self._activators[mode] = activator
-        logger.debug(f"Activateur enregistré pour le mode : {mode}")
+        logger.debug("Activateur enregistré pour un mode d'exécution.")
 
     def get(self, mode: Any) -> PluginActivator | None:
         return self._activators.get(mode)


### PR DESCRIPTION
Potential fix for [https://github.com/traoreera/xcore/security/code-scanning/28](https://github.com/traoreera/xcore/security/code-scanning/28)

To fix this, avoid logging raw `mode` values directly. Instead, log a constant/sanitized message that preserves observability without exposing potentially sensitive content.

Best single fix in this code:
- In `xcore/kernel/runtime/activator.py`, method `ActivatorRegistry.register`, replace:
  - `logger.debug(f"Activateur enregistré pour le mode : {mode}")`
- With:
  - `logger.debug("Activateur enregistré pour un mode d'exécution.")`

This keeps functionality unchanged (registry behavior is identical) while removing clear-text logging of dataflow-tainted input. No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent clear-text logging of potentially sensitive execution mode values in the activator registry.