### PR TITLE
fix: replace deprecated asyncio.get_event_loop() with get_running_loop()

### DIFF
--- a/xcore/kernel/sandbox/worker.py
+++ b/xcore/kernel/sandbox/worker.py
@@ -704,7 +704,7 @@ async def _run(plugin_dir: Path) -> None:
 
     reader = asyncio.StreamReader()
     protocol = asyncio.StreamReaderProtocol(reader)
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
 
     await loop.connect_read_pipe(lambda: protocol, sys.stdin)
 

--- a/xcore/marketplace/client.py
+++ b/xcore/marketplace/client.py
@@ -114,7 +114,7 @@ class MarketplaceClient:
                 return cached
 
         url = self._base_url + path
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         data = await loop.run_in_executor(None, lambda: self._http_get(url))
 
         if cache_key:
@@ -126,7 +126,7 @@ class MarketplaceClient:
         import asyncio
 
         url = self._base_url + path
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, lambda: self._http_post(url, body))
 
     def _http_get(self, url: str) -> Any:


### PR DESCRIPTION
Closes #212

Replaced deprecated `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in 2 files:
- `xcore/marketplace/client.py` (2 occurrences)
- `xcore/kernel/sandbox/worker.py` (1 occurrence)

All 1142 unit tests pass, ruff clean.

## Summary by Sourcery

Replace deprecated asyncio event loop access with the modern running-loop API across marketplace client and sandbox worker code.

Bug Fixes:
- Avoid potential runtime issues and deprecation-related behavior by no longer relying on asyncio.get_event_loop() in async contexts.

Enhancements:
- Update asyncio usage to use asyncio.get_running_loop() where an active event loop is guaranteed, aligning with current best practices.