### PR TITLE
fix: use SQLAlchemy dialect.is_async instead of string matching in MigrationRunner

### DIFF
--- a/tests/unit/services/test_migrations.py
+++ b/tests/unit/services/test_migrations.py
@@ -16,6 +16,11 @@ class TestMigrationRunner:
         runner = MigrationRunner("sqlite:///./test.db", migrations_dir=tmp_path)
         assert runner.db_url == "sqlite:///./test.db"
         assert runner.migrations_dir == tmp_path
+        assert runner._is_async_driver is False
+
+    def test_invalid_url_raises_migration_error(self):
+        with pytest.raises(MigrationError, match="Cannot parse database URL"):
+            MigrationRunner("not-a-valid-url://???")
 
     @pytest.mark.parametrize("url", [
         "postgresql+asyncpg://host/db",

--- a/tests/unit/services/test_migrations.py
+++ b/tests/unit/services/test_migrations.py
@@ -17,20 +17,23 @@ class TestMigrationRunner:
         assert runner.db_url == "sqlite:///./test.db"
         assert runner.migrations_dir == tmp_path
 
-    def test_is_async_asyncpg(self):
-        assert MigrationRunner("postgresql+asyncpg://host/db")._is_async() is True
+    @pytest.mark.parametrize("url", [
+        "postgresql+asyncpg://host/db",
+        "sqlite+aiosqlite:///./db",
+        "mysql+aiomysql://host/db",
+        "mysql+asyncmy://host/db",
+    ])
+    def test_is_async_async_drivers(self, url):
+        assert MigrationRunner(url)._is_async() is True
 
-    def test_is_async_aiosqlite(self):
-        assert MigrationRunner("sqlite+aiosqlite:///./db")._is_async() is True
-
-    def test_is_async_aiomysql(self):
-        assert MigrationRunner("mysql+aiomysql://host/db")._is_async() is True
-
-    def test_is_async_asyncmy(self):
-        assert MigrationRunner("mysql+asyncmy://host/db")._is_async() is True
-
-    def test_is_async_sync_driver(self):
-        assert MigrationRunner("sqlite:///./test.db")._is_async() is False
+    @pytest.mark.parametrize("url", [
+        "postgresql://host/db",
+        "sqlite:///./test.db",
+        "mysql://host/db",
+        "postgresql+psycopg2://host/db",
+    ])
+    def test_is_async_sync_drivers(self, url):
+        assert MigrationRunner(url)._is_async() is False
 
     def test_get_config_no_alembic_raises(self, tmp_path):
         runner = _make_runner(tmp_path)

--- a/xcore/services/database/migrations.py
+++ b/xcore/services/database/migrations.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import create_async_engine  # type: ignore
 
 from ...kernel.observability import get_logger
@@ -47,14 +48,7 @@ class MigrationRunner:
         return cfg
 
     def _is_async(self) -> bool:
-        """Détecte si l'URL utilise un driver async."""
-        async_markers = (
-            "+asyncpg",
-            "+aiosqlite",
-            "+aiomysql",
-            "+asyncmy",
-        )
-        return any(marker in self.db_url for marker in async_markers)
+        return make_url(self.db_url).get_dialect().is_async
 
     async def init(self, autogenerate: bool = True, message: str = "init") -> None:
         """

--- a/xcore/services/database/migrations.py
+++ b/xcore/services/database/migrations.py
@@ -35,6 +35,13 @@ class MigrationRunner:
     ) -> None:
         self.db_url = db_url
         self.migrations_dir = Path(migrations_dir).resolve()
+        try:
+            self._is_async_driver: bool = make_url(db_url).get_dialect().is_async
+        except Exception as e:
+            raise MigrationError(
+                f"Cannot parse database URL — check the format "
+                f"(e.g. 'postgresql+asyncpg://host/db'): {e}"
+            ) from e
 
     def _get_config(self):
         try:
@@ -48,7 +55,7 @@ class MigrationRunner:
         return cfg
 
     def _is_async(self) -> bool:
-        return make_url(self.db_url).get_dialect().is_async
+        return self._is_async_driver
 
     async def init(self, autogenerate: bool = True, message: str = "init") -> None:
         """


### PR DESCRIPTION
Closes #216

## Problem

`MigrationRunner._is_async()` detected async drivers by searching for substrings like `+asyncpg` or `+aiosqlite` in the URL string. This approach is fragile — it misses any driver not in the hardcoded list, breaks if a URL has an unusual format, and diverges from SQLAlchemy's own dialect metadata.

## Fix

Replace the string-matching logic with a single call to SQLAlchemy's own URL parser:

```python
from sqlalchemy.engine import make_url

def _is_async(self) -> bool:
    return make_url(self.db_url).get_dialect().is_async
```

`make_url` is already a transitive dependency (SQLAlchemy is required for `create_async_engine`), so no new dependency is introduced. `dialect.is_async` is the canonical SQLAlchemy 2.0 way to distinguish async dialects.

## Tests

Replaced the four separate per-driver test methods with two parametrized cases:

- **Async drivers:** `postgresql+asyncpg`, `sqlite+aiosqlite`, `mysql+aiomysql`, `mysql+asyncmy`
- **Sync drivers:** `postgresql`, `sqlite`, `mysql`, `postgresql+psycopg2`

All unit tests pass, ruff clean.

## Summary by Sourcery

Detect async database drivers in MigrationRunner using SQLAlchemy dialect metadata instead of URL substring matching.

Bug Fixes:
- Ensure async detection works reliably for all SQLAlchemy async dialect URLs without relying on hardcoded substrings.

Enhancements:
- Parametrize migration async-detection tests to cover multiple async and sync drivers more concisely.