### PR TITLE
add epheneral docs and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.4] - 2026-08-04
+
+### Added
+- **Ephemeral documentation**: New `doc/plugins/ephemeral-plugins.md` guide covering what Ephemeral mode is, when to use it, the warm pool lifecycle, configuration (per-plugin + global), plugin authoring, monitoring, and tuning advice. Registered in `mkdocs.yml`. Updated `execution-modes.md` (3-mode comparison table + Ephemeral section), `plugin-anatomy.md` (manifest reference), and `xcore-config.md` (`plugins.ephemeral` section).
+
+### Fixed
+- **Ephemeral per-plugin config**: `EphemeralActivator` now reads the `ephemeral:` block from `manifest.extra` when the manifest has no `ephemeral` attribute (the SDK's `PluginManifest` does not parse it as a field). Per-plugin config in `plugin.yaml` now works as documented, with global fallback preserved.
+- **warm_pool.py**: Replaced `logging.getLogger()` with `get_logger()` from `xcore.kernel.observability` to comply with project logging conventions. Converted all 11 logger calls from `%s` stdlib style to structured kwargs logging.
+
+### Documentation
+- **ROADMAP_PROGRESS.md**: Updated V2 progress from 70% to 85% — Ephemeral mode and Warm Pool were already implemented but marked as not done. Corrected status for Hot Cache (now ⚠️). Added "Points d'Attention" section noting duplicate `kernel/middlewares/` directory.
+
 ## [2.3.3] - 2026-06-08
 
 ### Added

--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -7,7 +7,7 @@ Ce document présente l'état actuel du framework XCore par rapport aux objectif
 | Version | Focus | État | Progression |
 | :--- | :--- | :--- | :--- |
 | **V1** | Fondation Kernel | **Terminé** | 100% |
-| **V2** | Industrialisation | **Avancé** | 70% |
+| **V2** | Industrialisation | **Avancé** | 85% |
 | **V3** | Distribution | **Démarré** | 25% |
 | **V4** | Cloud Native | **Concept** | 5% |
 | **V5** | Intelligence Native | **Concept** | 0% |
@@ -39,15 +39,15 @@ Ce document présente l'état actuel du framework XCore par rapport aux objectif
 
 | Fonctionnalité | État | Localisation / Note |
 | :--- | :---: | :--- |
-| ExecutionMode.EPHEMERAL | ❌ | Non implémenté |
-| Warm Pool Plugins | ❌ | Non implémenté |
+| ExecutionMode.EPHEMERAL | ✅ | `xcore/kernel/runtime/ephemeral_handler.py` + `EphemeralActivator` |
+| Warm Pool Plugins | ✅ | `xcore/kernel/runtime/warm_pool.py` (idle sweeper, semaphore, cold boot) |
 | Schema Registry | ✅ | `xcore/kernel/schema/registry.py` |
 | Validation automatique des contrats | ✅ | `xcore/kernel/schema/checker.py` |
-| OpenTelemetry complet | ⚠️ | Base présente dans `tracing.py`, stubs à lier |
-| Tracing distribué | ⚠️ | Middleware `TracingMiddleware` prêt |
-| Métriques Prometheus | ✅ | `xcore/kernel/observability/metrics.py` |
+| OpenTelemetry complet | ⚠️ | `tracing.py` = tracer maison noop, pas d'intégration OTel native |
+| Tracing distribué | ⚠️ | `TracingMiddleware` présent, backend noop |
+| Métriques Prometheus | ✅ | `xcore/kernel/observability/metrics.py` (wrapper + fallback memory) |
 | Plugin Registry privé | ✅ | `xcore/registry/index.py` |
-| Hot Cache avancé | ❌ | Services de cache basiques uniquement |
+| Hot Cache avancé | ⚠️ | `services/cache/` avec backends Redis + Memory, pas de TTL/LRU avancé |
 | Optimisations loader | ✅ | Tri topologique par vagues implémenté |
 
 ---
@@ -102,8 +102,12 @@ Ce document présente l'état actuel du framework XCore par rapport aux objectif
 - **Modularité (V1)** : Le cœur est extrêmement solide avec une isolation propre (Sandbox) et une gestion des dépendances par tri topologique.
 - **Contrats (V2)** : Le `SchemaRegistry` et le `BreakingChangeDetector` permettent déjà d'assurer la stabilité des APIs entre plugins.
 - **Tenancy (V3)** : Etonnamment, le multi-tenant est déjà bien intégré avec des wrappers pour la DB et le Cache, ce qui est normalement une feature plus tardive.
+- **Éphémère (V2)** : Le mode EPHEMERAL avec Warm Pool est pleinement fonctionnel (cold boot, idle sweeper, backpressure via semaphore).
+
+### Points d'Attention
+- **Code dupliqué** : `xcore/kernel/middlewares/` et `xcore/kernel/runtime/middlewares/` contiennent les mêmes fichiers. Le supervisor utilise `runtime/middlewares/`. L'autre dossier semble orphelin — à supprimer ou consolider.
 
 ### Chantiers Prioritaires
-1. **Observabilité (V2)** : Finaliser l'intégration native d'OpenTelemetry (actuellement en noop).
-2. **Éphémère (V2)** : Implémenter le mode d'exécution EPHEMERAL pour les fonctions Serverless-like.
+1. **Observabilité (V2)** : Finaliser l'intégration native d'OpenTelemetry (actuellement tracer maison noop).
+2. **Nettoyage code** : Supprimer `xcore/kernel/middlewares/` (doublon de `kernel/runtime/middlewares/`).
 3. **Distribution (V3)** : Commencer le clustering pour permettre la communication entre plusieurs instances XCore.

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,14 +1,17 @@
----
-title: Changelog
-icon: material/history
----
-
 # Changelog
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.3.4] - 2026-08-04
+
+### Fixed
+- **warm_pool.py**: Replaced `logging.getLogger()` with `get_logger()` from `xcore.kernel.observability` to comply with project logging conventions. Converted all 11 logger calls from `%s` stdlib style to structured kwargs logging.
+
+### Documentation
+- **ROADMAP_PROGRESS.md**: Updated V2 progress from 70% to 85% — Ephemeral mode and Warm Pool were already implemented but marked as not done. Corrected status for Hot Cache (now ⚠️). Added "Points d'Attention" section noting duplicate `kernel/middlewares/` directory.
 
 ## [2.3.3] - 2026-06-08
 

--- a/doc/kernel/execution-modes.md
+++ b/doc/kernel/execution-modes.md
@@ -1,26 +1,28 @@
 ---
 title: Execution Modes
-description: Comparison between Trusted and Sandboxed execution modes in Xcore.
+description: Comparison between Trusted, Sandboxed, and Ephemeral execution modes in Xcore.
 icon: material/shield-sync
 ---
 
 # Execution Modes
 
-Xcore supports two primary execution modes for plugins: **Trusted** and **Sandboxed**. The choice depends on the source of the plugin and the required level of performance versus security.
+Xcore supports three execution modes for plugins: **Trusted**, **Sandboxed**, and **Ephemeral**. The choice depends on the source of the plugin and the required level of performance, security, and isolation.
 
 ---
 
 ### Comparison Table
 
-| Feature | Trusted Mode | Sandboxed Mode |
-|---------|--------------|----------------|
-| **Process** | Main Process | Isolated Subprocess |
-| **Performance** | Native (Fast) | IPC Overhead (Medium) |
-| **Security** | None (Full Access) | High (Restricted) |
-| **Filesystem** | Full Access | Restricted (FilesystemGuard) |
-| **Imports** | All Python modules | Whitelisted modules only |
-| **Resource Limits** | Shared with App | CPU, Memory & Disk Quotas |
-| **Use Case** | Core business logic | 3rd-party, Untrusted, or Experimental |
+| Feature | Trusted Mode | Sandboxed Mode | Ephemeral Mode |
+|---------|--------------|----------------|----------------|
+| **Process** | Main Process | Isolated Subprocess | Main Process |
+| **Lifetime** | Persistent | Persistent | Per-call |
+| **Performance** | Native (Fast) | IPC Overhead (Medium) | Native (Fast) |
+| **Security** | None (Full Access) | High (Restricted) | None (Full Access) |
+| **State** | Persistent | Persistent | Stateless (zero) |
+| **Filesystem** | Full Access | Restricted (FilesystemGuard) | Full Access |
+| **Imports** | All Python modules | Whitelisted modules only | All Python modules |
+| **Resource Limits** | Shared with App | CPU, Memory & Disk Quotas | Bounded by WarmPool |
+| **Use Case** | Core business logic | 3rd-party, Untrusted, or Experimental | Serverless-style, hot reloads |
 
 ---
 
@@ -82,6 +84,29 @@ sequenceDiagram
 
 ---
 
+### Ephemeral Mode
+
+Ephemeral plugins run in the main process but are **created per call and destroyed right after**. No instance survives between two calls, giving zero implicit state, bounded memory, and per-call isolation — at near-native speed.
+
+This is the recommended mode for serverless-style actions and for plugins that are hot-reloaded frequently, since repeated reloads no longer leak memory.
+
+```yaml title="plugin.yaml"
+name: "image_processor"
+version: "1.0.0"
+execution_mode: "ephemeral"
+entry_point: "src/main.py"
+
+ephemeral:              # optional — falls back to plugins.ephemeral
+  pool_size: 2
+  max_idle_seconds: 60
+  max_concurrent: 10
+  boot_timeout: 5.0
+```
+
+See the [Ephemeral Plugins](../plugins/ephemeral-plugins.md) guide for the full lifecycle, configuration reference, and tuning advice.
+
+---
+
 ### Configuration
 
 #### Declaring Mode in `plugin.yaml`
@@ -98,7 +123,7 @@ resources:
   max_memory_mb: 256
 ```
 
-1.  Accepted values: `trusted` | `sandboxed`.
+1.  Accepted values: `trusted` | `sandboxed` | `ephemeral`. (`legacy` is deprecated.)
 
 ---
 
@@ -114,6 +139,10 @@ resources:
 !!! failure "DiskQuotaExceeded"
     If the `data/` directory exceeds `max_disk_mb`, the `SandboxProcessManager` will block further `call()` attempts.
     **Fix**: Clean up temporary files or increase the quota in `plugin.yaml`.
+
+!!! danger "Ephemeral: Boot Timeout"
+    If an ephemeral plugin's `on_load()` takes longer than `boot_timeout`, the instance boot fails.
+    **Fix**: Move heavy initialization out of `on_load()` or raise `boot_timeout` in the `ephemeral:` block.
 
 ---
 

--- a/doc/plugins/ephemeral-plugins.md
+++ b/doc/plugins/ephemeral-plugins.md
@@ -1,0 +1,229 @@
+---
+title: Ephemeral Plugins
+description: Serverless-like execution mode for stateless, scalable plugins with a warm pool.
+icon: material/lightning-bolt
+---
+
+# Ephemeral Plugins
+
+The **Ephemeral** mode is the third execution mode of Xcore, alongside [Trusted](./trusted-plugins.md) and [Sandboxed](./sandboxed-plugins.md). It is designed for **serverless-like**, **stateless** plugins that are created per call and destroyed right after.
+
+---
+
+### What is Ephemeral Mode?
+
+An Ephemeral plugin is **loaded, executed, and unloaded for every call**. No instance survives between two calls, which means:
+
+- **Zero implicit state**: the plugin cannot leak memory, connections, or cached values between requests.
+- **Bounded memory**: idle instances are reclaimed by an automatic sweeper.
+- **Per-call isolation**: even a crash in `handle()` discards the instance without affecting the next call.
+
+The kernel never knows the plugin is ephemeral: `EphemeralHandler` implements the same `PluginHandler` interface as `LifecycleManager` and `SandboxProcessManager`, so the supervisor, permissions, rate limiting, and HTTP routing all work unchanged.
+
+```mermaid
+sequenceDiagram
+    participant S as Supervisor
+    participant H as EphemeralHandler
+    participant P as WarmPool
+    participant I as Plugin Instance
+
+    S->>H: call("sum", {a:1, b:2})
+    H->>P: acquire()
+    alt pool available
+        P-->>I: warm instance (0ms)
+    else cold boot
+        P-->>I: new instance (3–6ms)
+    end
+    I->>I: handle("sum", {a:1, b:2})
+    I-->>H: {status:"ok", result:3}
+    H->>P: release() → back to pool or unload
+    H-->>S: {status:"ok", result:3}
+```
+
+---
+
+### Why Use Ephemeral Mode?
+
+| Scenario | Why Ephemeral |
+|---|---|
+| **Hot reload without memory leaks** | Repeated reloads no longer accumulate instances — each is garbage-collected after the call. |
+| **Unpredictable load spikes** | Cold boots absorb bursts; the warm pool covers the steady baseline. |
+| **Untrusted / third-party logic (faster than sandbox)** | Same-process execution gives near-native speed with per-call isolation. |
+| **Side-effect-heavy plugins** | Connections (DB, Redis) opened in `on_load` are torn down after each call — no dangling handles. |
+| **Serverless-style actions** | `pool_size=0` gives pure cold-boot execution, ideal for rare or low-frequency actions. |
+
+!!! warning "When NOT to use Ephemeral"
+    - **Stateful plugins** (sessions, in-memory caches, connection reuse) — each call starts from scratch.
+    - **High-frequency hot paths** — per-call `on_load` has a real cost. For millions of calls/second, prefer Trusted mode.
+    - **Background schedulers** (`@cron`, `@interval`) — scheduled tasks run against a handler, not a live instance.
+
+---
+
+### How It Works
+
+#### The Warm Pool
+
+The `WarmPool` (`xcore/kernel/runtime/warm_pool.py`) pre-loads `pool_size` instances at boot and keeps them ready:
+
+- **Pool hit**: an available instance is served immediately (~0 ms).
+- **Cold boot**: if the pool is empty, a new `LifecycleManager` is loaded on demand (3–6 ms per benchmark).
+- **Backpressure**: `max_concurrent` caps the total number of simultaneous instances (pool + cold). Beyond this, `acquire()` **waits** instead of unboundedly creating instances.
+- **Idle sweeper**: every 10 s, instances idle for more than `max_idle_seconds` are unloaded. The freshest `pool_size` instances are always kept.
+- **Error safety**: if `handle()` raises, the instance is **discarded** (not returned to the pool) — a potentially corrupted instance never gets reused.
+
+#### Call lifecycle
+
+1. `acquire()` — pool hit or cold boot (bounded by `max_concurrent`).
+2. `handle(action, payload)` — your plugin logic runs inside `src/main.py`.
+3. `release()` — the instance returns to the pool, or is unloaded if the pool is full.
+4. On error — `discard()` unloads the instance and releases its concurrency slot.
+
+---
+
+### Prerequisites
+
+- [x] [Xcore Installation](../installation.md) (≥ 2.3.3)
+- [x] A plugin with the standard structure (`plugin.yaml` + `src/main.py`)
+
+---
+
+### Configuration
+
+The ephemeral settings are resolved in this precedence order:
+
+1.  **Per-plugin**: the `ephemeral:` block in `plugin.yaml`.
+2.  **Global**: the `plugins.ephemeral:` section in `integration.yaml` / `xcore.yaml`.
+3.  **Defaults**: `EphemeralConfig()` if nothing is configured.
+
+#### 1. Per-plugin (`plugin.yaml`)
+
+```yaml linenums="1"
+name: "image_processor"
+version: "1.0.0"
+execution_mode: "ephemeral"   # (1)!
+entry_point: "src/main.py"
+
+ephemeral:                     # (2)!
+  pool_size: 2                # warm instances pre-loaded at boot
+  max_idle_seconds: 60        # unload idle instances after 60s
+  max_concurrent: 10          # max simultaneous instances (backpressure)
+  boot_timeout: 5             # seconds before a boot is considered failed
+```
+
+1.  Must be `ephemeral`. Values accepted: `trusted` | `sandboxed` | `legacy` | `ephemeral`.
+2.  Optional. Falls back to the global `plugins.ephemeral:` config.
+
+#### 2. Global (`integration.yaml`)
+
+```yaml linenums="1"
+plugins:
+  ephemeral:
+    pool_size: 1
+    max_idle_seconds: 60
+    max_concurrent: 10
+    boot_timeout: 5.0
+```
+
+Every ephemeral plugin **without** its own `ephemeral:` block inherits this configuration.
+
+#### 3. Defaults
+
+| Key | Type | Default | Description |
+|:--- | :--- | :--- | :--- |
+| `pool_size` | `int` | `0` | Warm instances pre-loaded. `0` = pure cold boot on every call. |
+| `max_idle_seconds` | `int` | `60` | Seconds before an idle instance is unloaded. |
+| `max_concurrent` | `int` | `10` | Max simultaneous instances (pool + cold boot). Beyond this, calls wait. |
+| `boot_timeout` | `float` | `5.0` | Seconds allowed for a single instance boot before it fails. |
+
+!!! tip "Tuning advice"
+    - Start with `pool_size: 1` and monitor `cold_boots` in the status endpoint.
+    - If cold boots stay at zero over time, raise `pool_size` to remove latency; if instances sit idle, lower it.
+    - `max_concurrent` is your safety valve against load spikes — set it to the maximum memory you can afford.
+
+---
+
+### Writing an Ephemeral Plugin
+
+The plugin source is **identical** to a Trusted plugin. Only the manifest changes.
+
+```python title="src/main.py"
+from xcore import TrustedBase, ok, error
+
+
+class Plugin(TrustedBase):
+
+    async def on_load(self):
+        self.logger.info("instance chargée", plugin="image_processor")
+
+    async def on_unload(self):
+        self.logger.info("instance déchargée", plugin="image_processor")
+
+    async def handle(self, action, payload):
+        if action == "ping":
+            return ok(msg="pong")
+        return error("action inconnue")
+```
+
+!!! warning "Stateless by design"
+    Do not cache data on `self` between calls, open long-lived connections in `on_load`, or start background tasks. Everything is torn down when the call finishes.
+
+---
+
+### Monitoring
+
+Each ephemeral plugin exposes its status through the standard plugin status endpoint (`supervisor.status()`):
+
+```json
+{
+  "name": "image_processor",
+  "mode": "ephemeral",
+  "state": "ready",
+  "pool": {
+    "pool_size": 2,
+    "available": 1,
+    "total_alive": 2,
+    "cold_boots": 4,
+    "max_idle_s": 60
+  },
+  "calls_total": 150,
+  "calls_error": 2,
+  "uptime_s": 3600.0
+}
+```
+
+| Field | Meaning |
+|:--- | :--- |
+| `pool.available` | Ready instances in the pool right now. |
+| `pool.total_alive` | Instances currently in existence (pool + in flight). |
+| `pool.cold_boots` | Total cold boots since start — if it climbs fast, `pool_size` is too low. |
+| `calls_error` | Calls that failed and triggered a `discard()`. |
+
+---
+
+### Common Errors & Pitfalls
+
+!!! danger "Boot timeout"
+    `Ephemeral boot timeout (Xs)` means `on_load()` took longer than `boot_timeout`.
+    **Fix**: move heavy initialization out of `on_load`, or raise `boot_timeout`.
+
+!!! warning "Instances are never reused after an error"
+    A failed `handle()` discards the instance. If your plugin fails often, expect more cold boots (visible in `pool.cold_boots`).
+
+!!! failure "Stateful behavior breaks silently"
+    Ephemeral plugins have no persistence. Rely on the cache (`self.get_service("cache")`) or the database for anything that must survive a call.
+
+---
+
+### See Also
+
+[Execution Modes](../kernel/execution-modes.md)
+:   Comparison of all execution modes.
+
+[Trusted Plugins](./trusted-plugins.md)
+:   Same plugin API without per-call isolation.
+
+[Plugin Anatomy](./plugin-anatomy.md)
+:   Structure and manifest reference.
+
+[Hot Reloading](../kernel/kernel.md)
+:   Ephemeral mode is the recommended companion for frequent hot reloads.

--- a/doc/plugins/plugin-anatomy.md
+++ b/doc/plugins/plugin-anatomy.md
@@ -111,6 +111,19 @@ extra:  # (2)!
 1.  Resolved from the host system's environment variables.
 2.  Available inside the plugin via `self.ctx.config`.
 
+#### 6. Ephemeral Settings
+Relevant only for `execution_mode: ephemeral`. Falls back to the global `plugins.ephemeral:` configuration.
+
+```yaml linenums="36"
+ephemeral:
+  pool_size: 2           # warm instances pre-loaded at boot
+  max_idle_seconds: 60   # unload idle instances after 60s
+  max_concurrent: 10     # max simultaneous instances
+  boot_timeout: 5.0      # seconds allowed for one boot
+```
+
+See the [Ephemeral Plugins](./ephemeral-plugins.md) guide for details.
+
 ---
 
 ### Manifest Reference
@@ -120,10 +133,11 @@ extra:  # (2)!
 | `name` | `str` | **Required** | Unique identifier for the plugin. |
 | `version` | `str` | **Required** | Plugin version (SemVer). |
 | `framework_version`| `str` | `"*"` | Minimum Xcore version required. |
-| `execution_mode` | `str` | `"legacy"` | `trusted` or `sandboxed`. |
+| `execution_mode` | `str` | `"legacy"` | `trusted`, `sandboxed`, or `ephemeral`. |
 | `entry_point` | `str` | `"src/main.py"` | Path to the file containing `class Plugin`. |
 | `requires` | `list` | `[]` | List of dependency objects (name + version). |
 | `permissions` | `list` | `[]` | Explicit permissions for services and IPC. |
+| `ephemeral` | `dict` | `{}` | Warm pool settings (only for `execution_mode: ephemeral`). |
 | `extra` | `dict` | `{}` | Arbitrary configuration parameters. |
 
 ---

--- a/doc/reference/xcore-config.md
+++ b/doc/reference/xcore-config.md
@@ -48,6 +48,26 @@ Configuration for the plugin supervisor and loader.
 | `strict_trusted`| `bool`| `true` | Enforce signature check for Trusted plugins. |
 | `interval` | `int` | `2` | Polling interval (seconds) for hot-reload. |
 | `entry_point` | `str` | `"src/main.py"`| Default entry point filename. |
+| `ephemeral` | `dict` | *See below* | Default warm pool config for Ephemeral plugins. |
+
+#### `plugins.ephemeral`
+Global defaults for [Ephemeral plugins](../plugins/ephemeral-plugins.md). Applied to every ephemeral plugin that does not declare its own `ephemeral:` block in `plugin.yaml`.
+
+| Key | Type | Default | Description |
+|:--- | :--- | :--- | :--- |
+| `pool_size` | `int` | `0` | Warm instances pre-loaded at boot. `0` = cold boot per call. |
+| `max_idle_seconds` | `int` | `60` | Seconds before an idle instance is unloaded. |
+| `max_concurrent` | `int` | `10` | Max simultaneous instances (pool + cold boot). |
+| `boot_timeout` | `float` | `5.0` | Seconds allowed for a single instance boot. |
+
+```yaml
+plugins:
+  ephemeral:
+    pool_size: 2
+    max_idle_seconds: 60
+    max_concurrent: 10
+    boot_timeout: 5.0
+```
 
 ---
 

--- a/doc/services/scheduler.md
+++ b/doc/services/scheduler.md
@@ -121,7 +121,7 @@ services:
     backend: "memory"       # str — "memory" | "redis". Default: "memory"
     timezone: "UTC"         # str — Standard IANA timezone. Default: "UTC"
     url: ~                  # str — Required when backend is "redis"
-
+    misfire_grace_time: float # execution grace time+++
     jobs:                   # (1)!
       - id: "global_sync"
         func: "myapp.tasks:sync_data"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - Plugin Anatomy: plugins/plugin-anatomy.md
       - Trusted Plugins: plugins/trusted-plugins.md
       - Sandboxed Plugins: plugins/sandboxed-plugins.md
+      - Ephemeral Plugins: plugins/ephemeral-plugins.md
       - Events & Hooks: plugins/events-hooks.md
       - Permissions & Policies: plugins/permissions.md
   - Services:

--- a/tests/unit/kernel/test_ephemeral_coverage.py
+++ b/tests/unit/kernel/test_ephemeral_coverage.py
@@ -530,3 +530,33 @@ class TestActivatorCoverage:
                 handler = await activator.activate(manifest, loader)
 
         assert handler._config is global_config
+
+    async def test_ephemeral_activator_uses_extra_manifest_config(self):
+        """Si le bloc `ephemeral:` est dans manifest.extra (PluginManifest), il est utilisé."""
+        from xcore.kernel.runtime.activator import EphemeralActivator
+
+        manifest = _manifest(pool_size=0)
+        manifest.ephemeral = None
+        # Le PluginManifest ne parse pas `ephemeral:` → il tombe dans extra
+        manifest.extra = {"ephemeral": {"pool_size": 4, "max_concurrent": 7}}
+
+        loader = MagicMock()
+        loader._config.strict_trusted = False
+        loader._ctx = _ctx()
+        loader._caller = None
+
+        mock_lm = _make_lm()
+
+        with patch("xcore.kernel.security.validation.ASTScanner") as mock_scanner_cls:
+            scanner = MagicMock()
+            scan_result = MagicMock()
+            scan_result.passed = True
+            scanner.scan.return_value = scan_result
+            mock_scanner_cls.return_value = scanner
+
+            with patch("xcore.kernel.runtime.lifecycle.LifecycleManager", return_value=mock_lm):
+                activator = EphemeralActivator()
+                handler = await activator.activate(manifest, loader)
+
+        assert handler._config.pool_size == 4
+        assert handler._config.max_concurrent == 7

--- a/xcore/configurations/sections.py
+++ b/xcore/configurations/sections.py
@@ -186,6 +186,7 @@ class SchedulerConfig:
     backend: str = "memory"  # memory | redis | database
     url: str = "redis://localhost:6379/0"
     timezone: str = "UTC"
+    misfire_grace_time: float = 60
     jobs: list[dict[str, Any]] = field(default_factory=list)
 
 

--- a/xcore/kernel/runtime/activator.py
+++ b/xcore/kernel/runtime/activator.py
@@ -139,6 +139,11 @@ class EphemeralActivator(PluginActivator):
 
         # Résolution de la config : manifest > global > défaut
         eph_raw = getattr(manifest, "ephemeral", None)
+        if eph_raw is None:
+            # Le PluginManifest ne parse pas le bloc `ephemeral:` → il est dans extra
+            extra = getattr(manifest, "extra", {})
+            if isinstance(extra, dict):
+                eph_raw = extra.get("ephemeral")
         if isinstance(eph_raw, dict):
             config = EphemeralConfig.from_dict(eph_raw)
         elif isinstance(eph_raw, EphemeralConfig):

--- a/xcore/kernel/runtime/warm_pool.py
+++ b/xcore/kernel/runtime/warm_pool.py
@@ -19,14 +19,15 @@ Aucune mutation sans le lock — safe pour les appels concurrents.
 from __future__ import annotations
 
 import asyncio
-import logging
 import time
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .lifecycle import LifecycleManager
 
-logger = logging.getLogger("xcore.runtime.warm_pool")
+from ..observability import get_logger
+
+logger = get_logger("xcore.runtime.warm_pool")
 
 
 class _PoolEntry:
@@ -103,7 +104,7 @@ class WarmPool:
     async def start(self) -> None:
         """Pré-charge pool_size instances. Appelé par EphemeralActivator au boot."""
         if self._pool_size <= 0:
-            logger.debug("[%s] warm pool désactivé (pool_size=0)", self._manifest.name)
+            logger.debug("warm pool desabled", plugin=self._manifest.name, pool_size=0)
             return
 
         boots = [self._boot_one() for _ in range(self._pool_size)]
@@ -113,16 +114,16 @@ class WarmPool:
         for r in results:
             if isinstance(r, Exception):
                 logger.warning(
-                    "[%s] warm pool : échec boot initial : %s",
-                    self._manifest.name,
-                    r,
+                    "warm pool échec boot initial",
+                    plugin=self._manifest.name,
+                    erreur=str(r),
                 )
 
         logger.info(
-            "[%s] warm pool prêt — %d/%d instance(s)",
-            self._manifest.name,
-            ok,
-            self._pool_size,
+            "warm pool prêt",
+            plugin=self._manifest.name,
+            ready=ok,
+            total=self._pool_size,
         )
 
         # Démarrage du worker de nettoyage idle
@@ -153,7 +154,7 @@ class WarmPool:
         # Tente de prendre depuis le pool sans bloquer
         try:
             entry = self._available.get_nowait()
-            logger.debug("[%s] warm pool hit", self._manifest.name)
+            logger.debug("warm pool hit", plugin=self._manifest.name)
             return entry.manager
         except asyncio.QueueEmpty:
             pass
@@ -182,7 +183,9 @@ class WarmPool:
             entry.touch()
             await self._available.put(entry)
             self._semaphore.release()
-            logger.debug("[%s] warm pool release → retour au pool", self._manifest.name)
+            logger.debug(
+                "warm pool release → retour au pool", plugin=self._manifest.name
+            )
         else:
             # Pool plein → décharge
             await self._safe_unload(mgr)
@@ -190,7 +193,7 @@ class WarmPool:
                 self._total -= 1
             self._semaphore.release()
             logger.debug(
-                "[%s] warm pool release → décharge (pool plein)", self._manifest.name
+                "warm pool release → décharge (pool plein)", plugin=self._manifest.name
             )
 
     async def discard(self, mgr: "LifecycleManager") -> None:
@@ -267,7 +270,7 @@ class WarmPool:
             raise
 
         self._cold_boot_count += 1
-        logger.debug("[%s] cold boot OK (total=%d)", self._manifest.name, self._total)
+        logger.debug("cold boot OK", plugin=self._manifest.name, total=self._total)
         return lm
 
     async def _safe_unload(self, mgr: "LifecycleManager") -> None:
@@ -276,9 +279,9 @@ class WarmPool:
             await mgr.unload()
         except Exception as e:
             logger.warning(
-                "[%s] erreur déchargement instance : %s",
-                self._manifest.name,
-                e,
+                "erreur déchargement instance",
+                plugin=self._manifest.name,
+                erreur=str(e),
             )
 
     # ── Worker de nettoyage idle ──────────────────────────────────────────────
@@ -323,16 +326,16 @@ class WarmPool:
                 async with self._lock:
                     self._total -= 1
                 logger.debug(
-                    "[%s] idle sweep : instance déchargée (idle=%.0fs)",
-                    self._manifest.name,
-                    entry.idle_seconds,
+                    "idle sweep : instance déchargée",
+                    plugin=self._manifest.name,
+                    idle_s=round(entry.idle_seconds),
                 )
 
             if to_discard:
                 logger.info(
-                    "[%s] idle sweep : %d instance(s) déchargée(s)",
-                    self._manifest.name,
-                    len(to_discard),
+                    "idle sweep : instances déchargées",
+                    plugin=self._manifest.name,
+                    count=len(to_discard),
                 )
 
     # ── Shutdown ──────────────────────────────────────────────────────────────
@@ -361,9 +364,9 @@ class WarmPool:
             self._total = 0
 
         logger.info(
-            "[%s] warm pool arrêté (%d instance(s) déchargée(s))",
-            self._manifest.name,
-            count,
+            "warm pool arrêté",
+            plugin=self._manifest.name,
+            unloaded=count,
         )
 
     # ── Stats ─────────────────────────────────────────────────────────────────

--- a/xcore/kernel/runtime/warm_pool.py
+++ b/xcore/kernel/runtime/warm_pool.py
@@ -104,7 +104,7 @@ class WarmPool:
     async def start(self) -> None:
         """Pré-charge pool_size instances. Appelé par EphemeralActivator au boot."""
         if self._pool_size <= 0:
-            logger.debug("warm pool desabled", plugin=self._manifest.name, pool_size=0)
+            logger.debug("warm pool disabled (pool_size=0)", plugin=self._manifest.name, pool_size=0)
             return
 
         boots = [self._boot_one() for _ in range(self._pool_size)]

--- a/xcore/services/scheduler/service.py
+++ b/xcore/services/scheduler/service.py
@@ -153,7 +153,7 @@ class SchedulerService(BaseService):
             job_defaults={
                 "coalesce": True,  # fusionne les déclenchements manqués en un seul
                 "max_instances": 1,  # pas d'exécutions parallèles du même job
-                "misfire_grace_time": 60,
+                "misfire_grace_time": self._config.misfire_grace_time,
             },
             timezone=self._config.timezone,
         )


### PR DESCRIPTION
add change logs for docs

## Summary by Sourcery

Document and finalize Ephemeral execution mode support, adjust related configuration and roadmap, and align warm pool logging and scheduler behavior with existing observability and configurability patterns.

New Features:
- Introduce comprehensive Ephemeral plugin documentation, including lifecycle, warm pool behavior, configuration, monitoring, and guidance, and add it to the docs navigation.
- Expose global `plugins.ephemeral` configuration in xcore config, and support per-plugin `ephemeral` manifest settings for execution_mode `ephemeral`.
- Allow scheduler jobs to configure `misfire_grace_time` via SchedulerConfig and YAML, instead of using a hardcoded default.

Bug Fixes:
- Ensure EphemeralActivator correctly reads the `ephemeral` block from `manifest.extra` when the manifest type does not parse it as a dedicated field, so per-plugin ephemeral config is honored.
- Update warm_pool logging to use the project’s structured logger via `get_logger` and structured kwargs instead of stdlib string formatting.

Enhancements:
- Extend execution modes documentation to include Ephemeral mode with an updated comparison table and dedicated section explaining usage and configuration.
- Update plugin anatomy docs and manifest reference to describe Ephemeral execution mode and its `ephemeral` configuration block.
- Refine roadmap progress and feature status to reflect implemented Ephemeral mode, Warm Pool, and cache capabilities, and add notes about duplicated middleware code that needs cleanup.

Documentation:
- Add a dedicated Ephemeral Plugins guide and link it from the plugins documentation and related reference pages.
- Clarify execution modes, plugin anatomy, and configuration docs to cover Ephemeral mode, warm pool settings, and related best practices.
- Update roadmap and changelog documentation to reflect current implementation status of Ephemeral mode, Warm Pool, observability, and cache features.

Tests:
- Add unit coverage to ensure EphemeralActivator uses `manifest.extra.ephemeral` when the explicit `ephemeral` attribute is missing, validating per-plugin configuration merging behavior.

Chores:
- Record the 2.3.4 release in both CHANGELOG.md and doc/changelog.md, including Ephemeral documentation, config fixes, logging updates, and roadmap corrections.